### PR TITLE
Share last_irreversible_block_num updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Content-Type: application/json
 
 ## What jussi does
 ### At Startup
-1. parse the upstream config and build the routing, caching, timeout data structures 
+1. parse the upstream config and build the routing, caching, timeout data structures
 1. open websocket and/or http connections to upstreams
 1. initialize memory cache and open connections to redis cache
 1. register route and error handlers
@@ -65,4 +65,3 @@ Content-Type: application/json
 1. return single jsonrpc response or assembled jsonrpc responses for batch requests
 1. cache response in redis cache
 1. cache response in memory
-

--- a/jussi/cache/cache_group.py
+++ b/jussi/cache/cache_group.py
@@ -20,10 +20,10 @@ from ..utils import is_batch_jsonrpc
 from ..validators import is_valid_jussi_response
 from ..validators import is_valid_non_error_single_jsonrpc_response
 from .ttl import TTL
+from .utils import irreversible_ttl
 from .utils import jsonrpc_cache_key
 from .utils import merge_cached_response
 from .utils import merge_cached_responses
-from .utils import irreversible_ttl
 
 logger = logging.getLogger(__name__)
 
@@ -173,7 +173,6 @@ class CacheGroup(object):
                     await self.get('last_irreversible_block_num')
                 ttl = irreversible_ttl(response,
                                        last_irreversible_block_num)
-
             elif ttl == TTL.NO_CACHE:
                 continue
             if isinstance(ttl, TTL):

--- a/jussi/cache/utils.py
+++ b/jussi/cache/utils.py
@@ -18,17 +18,6 @@ def jsonrpc_cache_key(single_jsonrpc_request: SingleJsonRpcRequest) -> str:
     return str(single_jsonrpc_request.urn)
 
 
-def ttl_from_jsonrpc_request(single_jsonrpc_request: SingleJsonRpcRequest,
-                             last_irreversible_block_num: int=0,
-                             jsonrpc_response: dict=None) -> TTL:
-    ttl = single_jsonrpc_request.upstream.ttl
-    if ttl == TTL.NO_EXPIRE_IF_IRREVERSIBLE:
-        ttl = irreversible_ttl(jsonrpc_response, last_irreversible_block_num)
-    if isinstance(ttl, TTL):
-        ttl = ttl.value
-    return ttl
-
-
 def irreversible_ttl(jsonrpc_response: dict=None,
                      last_irreversible_block_num: int=0) -> TTL:
     if not jsonrpc_response:

--- a/jussi/middlewares/caching.py
+++ b/jussi/middlewares/caching.py
@@ -40,9 +40,7 @@ async def cache_response(request: HTTPRequest, response: HTTPResponse) -> None:
         cache_group = request.app.config.cache_group
         jsonrpc_request = request.json
         jsonrpc_response = ujson.loads(response.body)
-        last_irreversible_block_num = request.app.config.last_irreversible_block_num or 15_000_000
         asyncio.shield(cache_group.cache_jsonrpc_response(jsonrpc_request,
-                                                          jsonrpc_response,
-                                                          last_irreversible_block_num))
+                                                          jsonrpc_response))
     except Exception as e:
         logger.error('error caching response: %s', e)

--- a/jussi/middlewares/update_block_num.py
+++ b/jussi/middlewares/update_block_num.py
@@ -17,7 +17,6 @@ async def update_last_irreversible_block_num(request: HTTPRequest, response: HTT
     if request.method != 'POST':
         return
     try:
-        app = request.app
         jsonrpc_request = request.json
         jsonrpc_response = ujson.loads(response.body)
         if is_get_dynamic_global_properties_request(jsonrpc_request):

--- a/jussi/middlewares/update_block_num.py
+++ b/jussi/middlewares/update_block_num.py
@@ -22,8 +22,9 @@ async def update_last_irreversible_block_num(request: HTTPRequest, response: HTT
         jsonrpc_response = ujson.loads(response.body)
         if is_get_dynamic_global_properties_request(jsonrpc_request):
             last_irreversible_block_num = jsonrpc_response['result']['last_irreversible_block_num']
-            assert last_irreversible_block_num >= app.config.last_irreversible_block_num
-            app.config.last_irreversible_block_num = last_irreversible_block_num
+            cache_group = request.app.config.cache_group
+            await cache_group.set('last_irreversible_block_num',
+                                  last_irreversible_block_num)
             logger.debug(
                 f'updated last_irreversible_block_num: {last_irreversible_block_num}')
     except Exception:

--- a/jussi/serve.py
+++ b/jussi/serve.py
@@ -2,8 +2,6 @@
 import argparse
 import os
 
-from distutils.util import strtobool
-
 from sanic import Sanic
 
 import jussi.errors
@@ -15,6 +13,22 @@ from jussi.typedefs import WebApp
 
 STEEMIT_MAX_BLOCK_SIZE = 393216000
 REQUEST_MAX_SIZE = STEEMIT_MAX_BLOCK_SIZE + 1000
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 def setup_routes(app: WebApp) -> WebApp:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -851,6 +851,7 @@ def test_cli(app, loop, test_client):
 @pytest.fixture
 def mocked_app_test_cli(app, loop, test_client):
     with asynctest.patch('jussi.ws.pool.connect') as mocked_connect:
+
         mocked_ws_conn = asynctest.CoroutineMock()
         mocked_ws_conn.send = asynctest.CoroutineMock()
         mocked_ws_conn.send.return_value = None

--- a/tests/test_cache_group.py
+++ b/tests/test_cache_group.py
@@ -272,7 +272,8 @@ async def test_cache_group_cache_jsonrpc_response(
     key = jsonrpc_cache_key(req)
 
     assert await cache_group.get(key) is None
-    await cache_group.cache_jsonrpc_response(req, resp, 15_000_000)
+    await cache_group.set('last_irreversible_block_num', 15_000_000)
+    await cache_group.cache_jsonrpc_response(req, resp)
 
     for cache in caches:
         assert await cache.get(key) == resp, f'key:{key} urn:{req.urn}'
@@ -294,7 +295,8 @@ async def test_cache_group_get_jsonrpc_response(steemd_requests_and_responses):
     resp['jsonrpc'] = '2.0'
     key = jsonrpc_cache_key(req)
     assert await cache_group.get(key) is None
-    await cache_group.cache_jsonrpc_response(req, resp, 15_000_000)
+    await cache_group.set('last_irreversible_block_num', 15_000_000)
+    await cache_group.cache_jsonrpc_response(req, resp)
 
     assert await cache_group.get(key) == resp
     assert await cache_group.get_jsonrpc_response(req) == resp
@@ -318,7 +320,8 @@ async def test_cache_group_get_single_jsonrpc_response(
     resp['jsonrpc'] = '2.0'
     key = jsonrpc_cache_key(req)
     assert await cache_group.get(key) is None
-    await cache_group.cache_jsonrpc_response(req, resp, 15_000_000)
+    await cache_group.set('last_irreversible_block_num', 15_000_000)
+    await cache_group.cache_jsonrpc_response(req, resp)
     assert await cache_group.get(key) == resp
     assert await cache_group.get_single_jsonrpc_response(req) == resp
     for cache in caches:
@@ -344,7 +347,8 @@ async def test_cache_group_get_batch_jsonrpc_responses(
     batch_resp = [resp, resp, resp]
     key = jsonrpc_cache_key(req)
     assert await cache_group.get(key) is None
-    await cache_group.cache_jsonrpc_response(batch_req, batch_resp, 15_000_000)
+    await cache_group.set('last_irreversible_block_num', 15_000_000)
+    await cache_group.cache_jsonrpc_response(batch_req, batch_resp)
     assert await cache_group.get(key) == resp
     assert await cache_group.get_batch_jsonrpc_responses(
         batch_req) == batch_resp

--- a/tests/test_cache_middleware.py
+++ b/tests/test_cache_middleware.py
@@ -5,36 +5,79 @@ import json
 import pytest
 
 
-req = {"id": 1, "jsonrpc": "2.0", "method": "get_block", "params": [1000]}
+req = {"id": 1, "jsonrpc": "2.0", "method": "get_dynamic_global_properties"}
 
 expected_steemd_response = {
-    "id": 1,
+    "id": "1",
     "result": {
-        "previous": "000003e7c4fd3221cf407efcf7c1730e2ca54b05",
-        "timestamp": "2016-03-24T16:55:30",
-        "witness": "initminer",
-        "transaction_merkle_root": "0000000000000000000000000000000000000000",
-        "extensions": [],
-        "witness_signature": "207f15578cac20ac0e8af1ebb8f463106b8849577e21cca9fc60da146d1d95df88072dedc6ffb7f7f44a9185bbf9bf8139a5b4285c9f423843720296a44d428856",
-        "transactions": [],
-        "block_id": "000003e8b922f4906a45af8e99d86b3511acd7a5",
-        "signing_key": "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX",
-        "transaction_ids": []}}
+        "average_block_size": 16112,
+        "confidential_sbd_supply": "0.000 SBD",
+        "confidential_supply": "0.000 STEEM",
+        "current_aslot": 19615022,
+        "current_reserve_ratio": 1243817,
+        "current_sbd_supply": "8016379.428 SBD",
+        "current_supply": "263590437.017 STEEM",
+        "current_witness": "good-karma",
+        "head_block_id": "012a58ebf2e150d2200da72acff4c6b272915e08",
+        "head_block_number": 19552491,
+        "id": 0,
+        "last_irreversible_block_num": 19552476,
+        "max_virtual_bandwidth": "1643338184785920000",
+        "maximum_block_size": 65536,
+        "num_pow_witnesses": 172,
+        "participation_count": 128,
+        "pending_rewarded_vesting_shares": "298814345.817945 VESTS",
+        "pending_rewarded_vesting_steem": "145258.167 STEEM",
+        "recent_slots_filled": "340282366920938463463374607431768211455",
+        "sbd_interest_rate": 0,
+        "sbd_print_rate": 10000,
+        "time": "2018-02-03T17:51:06",
+        "total_pow": 514415,
+        "total_reward_fund_steem": "0.000 STEEM",
+        "total_reward_shares2": "0",
+        "total_vesting_fund_steem": "195640068.504 STEEM",
+        "total_vesting_shares": "400228023408.017941 VESTS",
+        "virtual_supply": "265290623.534 STEEM",
+        "vote_power_reserve_rate": 10
+    }
+}
+
 
 expected_response = {
     "id": 1,
     "jsonrpc": "2.0",
     "result": {
-        "previous": "000003e7c4fd3221cf407efcf7c1730e2ca54b05",
-        "timestamp": "2016-03-24T16:55:30",
-        "witness": "initminer",
-        "transaction_merkle_root": "0000000000000000000000000000000000000000",
-        "extensions": [],
-        "witness_signature": "207f15578cac20ac0e8af1ebb8f463106b8849577e21cca9fc60da146d1d95df88072dedc6ffb7f7f44a9185bbf9bf8139a5b4285c9f423843720296a44d428856",
-        "transactions": [],
-        "block_id": "000003e8b922f4906a45af8e99d86b3511acd7a5",
-        "signing_key": "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX",
-        "transaction_ids": []}}
+        "average_block_size": 16112,
+        "confidential_sbd_supply": "0.000 SBD",
+        "confidential_supply": "0.000 STEEM",
+        "current_aslot": 19615022,
+        "current_reserve_ratio": 1243817,
+        "current_sbd_supply": "8016379.428 SBD",
+        "current_supply": "263590437.017 STEEM",
+        "current_witness": "good-karma",
+        "head_block_id": "012a58ebf2e150d2200da72acff4c6b272915e08",
+        "head_block_number": 19552491,
+        "id": 0,
+        "last_irreversible_block_num": 19552476,
+        "max_virtual_bandwidth": "1643338184785920000",
+        "maximum_block_size": 65536,
+        "num_pow_witnesses": 172,
+        "participation_count": 128,
+        "pending_rewarded_vesting_shares": "298814345.817945 VESTS",
+        "pending_rewarded_vesting_steem": "145258.167 STEEM",
+        "recent_slots_filled": "340282366920938463463374607431768211455",
+        "sbd_interest_rate": 0,
+        "sbd_print_rate": 10000,
+        "time": "2018-02-03T17:51:06",
+        "total_pow": 514415,
+        "total_reward_fund_steem": "0.000 STEEM",
+        "total_reward_shares2": "0",
+        "total_vesting_fund_steem": "195640068.504 STEEM",
+        "total_vesting_shares": "400228023408.017941 VESTS",
+        "virtual_supply": "265290623.534 STEEM",
+        "vote_power_reserve_rate": 10
+    }
+}
 
 
 @pytest.mark.live
@@ -42,7 +85,7 @@ async def test_cache_response_middleware(test_cli):
     response = await test_cli.post('/', json=req)
     assert await response.json() == expected_steemd_response
     response = await test_cli.post('/', json=req)
-    assert response.headers['x-jussi-cache-hit'] == 'steemd.database_api.get_block.params=[1000]'
+    assert response.headers['x-jussi-cache-hit'] == 'steemd.database_api.get_dynamic_global_properties'
 
 
 async def test_mocked_cache_response_middleware(mocked_app_test_cli, mocker):
@@ -53,6 +96,6 @@ async def test_mocked_cache_response_middleware(mocked_app_test_cli, mocker):
     assert 'x-jussi-cache-hit' not in response.headers
     assert await response.json() == expected_response
 
-    response = await test_cli.post('/', json=req)
-    assert response.headers['x-jussi-cache-hit'] == 'steemd.database_api.get_block.params=[1000]'
+    response = await test_cli.post('/', json=req, headers={'x-jussi-request-id': '1'})
+    assert response.headers['x-jussi-cache-hit'] == 'steemd.database_api.get_dynamic_global_properties'
     assert await response.json() == expected_response

--- a/tests/test_method_ttls.py
+++ b/tests/test_method_ttls.py
@@ -1,27 +1,19 @@
 # -*- coding: utf-8 -*-
 import pytest
 from jussi.cache.ttl import TTL
-from jussi.cache.utils import ttl_from_jsonrpc_request
+from jussi.cache.utils import irreversible_ttl
+
 from jussi.request import JussiJSONRPCRequest
 from jussi.upstream import _Upstreams
-from jussi.upstream import DEFAULT_UPSTREAM_CONFIG
-
-
-class AttrDict(dict):
-    def __init__(self, *args, **kwargs):
-        super(AttrDict, self).__init__(*args, **kwargs)
-        self.__dict__ = self
-
+from .conftest import TEST_UPSTREAM_CONFIG
+from .conftest import AttrDict
 
 dummy_request = AttrDict()
 dummy_request.headers = dict()
 dummy_request['jussi_request_id'] = '123456789012345'
 dummy_request.app = AttrDict()
 dummy_request.app.config = AttrDict()
-dummy_request.app.config.upstreams = _Upstreams(DEFAULT_UPSTREAM_CONFIG, validate=False)
-
-
-SBDS_DEFAULT_CACHE = 3
+dummy_request.app.config.upstreams = _Upstreams(TEST_UPSTREAM_CONFIG, validate=False)
 
 
 ttl_rpc_req = JussiJSONRPCRequest.from_request(dummy_request, 0, {"id": "1", "jsonrpc": "2.0",
@@ -40,11 +32,8 @@ rpc_resp = {
         "signing_key": "STM8GC13uCZbP44HzMLV6zPZGwVQ8Nt4Kji8PapsPiNq1BK153XTX",
         "transaction_ids": []}}
 
-non_ttl_rpc_req = JussiJSONRPCRequest.from_request(dummy_request, 0, {"id": "1", "jsonrpc": "2.0",
-                                                                      "method": "sbds.get_block", "params": [1000]})
 
-
-@pytest.mark.parametrize('rpc_req, rpc_resp, last_block_num,expected', [
+@pytest.mark.parametrize('rpc_req, rpc_resp, last_block_num, expected', [
     # don't cache when last_block_num < response block_num
     (ttl_rpc_req, rpc_resp, 0, TTL.NO_CACHE),
     (ttl_rpc_req, rpc_resp, 999, TTL.NO_CACHE),
@@ -56,13 +45,9 @@ non_ttl_rpc_req = JussiJSONRPCRequest.from_request(dummy_request, 0, {"id": "1",
     # don't cache when bad/missing response block_num
     (ttl_rpc_req, {}, 2000, TTL.NO_CACHE),
 
-    # don't adjust ttl for non EXPIRE_IF_IRREVERSIBLE methods
-    (non_ttl_rpc_req, rpc_resp, 2000, SBDS_DEFAULT_CACHE),
-
-
 ])
 def test_ttls(rpc_req, rpc_resp, last_block_num, expected):
-    ttl = ttl_from_jsonrpc_request(rpc_req, last_block_num, rpc_resp)
+    ttl = irreversible_ttl(rpc_resp, last_block_num)
     if isinstance(expected, TTL):
         expected = expected.value
     assert ttl == expected


### PR DESCRIPTION
Closes #109 

Adjust to condenser's massive reduction in calls to `get_dynamic_global_properties` by sharing `last_irreversible_block_num` between processes and instances. 