### PR TITLE
Update transfers regex workaround to work with appbase

### DIFF
--- a/DEV_config.json
+++ b/DEV_config.json
@@ -15,7 +15,9 @@
     {
         "name": "appbase",
         "urls": [
-            ["appbase", "wss://steemd.steemitdev.com"]
+            ["appbase", "wss://steemd.steemitdev.com"],
+            ["appbase.condenser_api.get_account_history", "wss://ahnode.steemitdev.com"],
+            ["appbase.condenser_api.get_ops_in_block", "wss://ahnode.steemitdev.com"]
         ],
         "ttls": [
             ["appbase.account_history_api", -1],

--- a/jussi/upstream.py
+++ b/jussi/upstream.py
@@ -89,7 +89,7 @@ class _Upstreams(object):
     @functools.lru_cache(8192)
     def url(self, request_urn) -> str:
         try:
-            if request_urn.api == 'database_api'and ACCOUNT_TRANSFER_PATTERN.match(
+            if (request_urn.api == 'database_api' or request_urn.api == 'condenser_api') and ACCOUNT_TRANSFER_PATTERN.match(
                     request_urn.params[0]):
                 logger.debug('matched')
                 url = os.environ.get('JUSSI_ACCOUNT_TRANSFER_STEEMD_URL')


### PR DESCRIPTION
This updates the transfers regex workaround to work with appbase (`condenser_api` instead of just `database_api`)

Also, it updates the dev config file to split account history calls to the nodes that have that available.