### PR TITLE
Add timeouts to cache reads

### DIFF
--- a/jussi/listeners.py
+++ b/jussi/listeners.py
@@ -76,9 +76,12 @@ def setup_listeners(app: WebApp) -> WebApp:
     async def setup_caching(app: WebApp, loop) -> None:
         logger = app.config.logger
         logger.info('before_server_start -> setup_caching')
+        args = app.config.args
         cache_group = setup_caches(app, loop)
         app.config.cache_group = cache_group
         app.config.last_irreversible_block_num = 15_000_000
+        app.config.cache_read_timeout = args.cache_read_timeout
+        app.config.cache_write_timeout = args.cache_write_timeout
 
     @app.listener('after_server_stop')
     async def close_websocket_connection_pools(app: WebApp, loop) -> None:

--- a/jussi/serve.py
+++ b/jussi/serve.py
@@ -75,6 +75,10 @@ def parse_args(args: list = None):
     parser.add_argument('--redis_port', type=int, default=6379)
     parser.add_argument('--redis_namespace', type=str, default='jussi')
 
+    # cache config
+    parser.add_argument('--cache_read_timeout', type=float, default=1.0)
+    parser.add_argument('--cache_write_timeout', type=float, default=5.0)
+
     return parser.parse_args(args=args)
 
 

--- a/service/jussi/run
+++ b/service/jussi/run
@@ -25,4 +25,5 @@ exec 2>&1 \
       --test_upstream_urls "${JUSSI_TEST_UPSTREAM_URLS:- True}" \
       --redis_host "${JUSSI_REDIS_HOST}" \
       --redis_port "${JUSSI_REDIS_PORT:-6379}" \
-      --redis_namespace "${JUSSI_REDIS_NAMESPACE:-jussi}"
+      --redis_namespace "${JUSSI_REDIS_NAMESPACE:-jussi}" \
+      --cache_read_timeout "${JUSSI_CACHE_READ_TIMEOUT:-1.0}"


### PR DESCRIPTION
Closes #124 Cache read timeouts too high

Adds support for a timeout on reading from the caches before making upstream request