### PR TITLE
Remove config complexity from service/cli/env_var invocation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,11 +1,8 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 
-
 [dev-packages]
-
 sanic = "==0.6.0"
 asynctest = "*"
 autoflake = "*"
@@ -39,9 +36,7 @@ isort = "*"
 pydevd = "*"
 line-profiler = "*"
 
-
 [packages]
-
 ujson = "*"
 aiohttp = "*"
 toolz = "*"
@@ -62,7 +57,7 @@ aiocache = {extras = ["memcached", "redis"]}
 websockets = "*"
 sanic = "==0.6.0"
 msgpack = "*"
+configargparse = "*"
 
 [requires]
-
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "88ac98c6f563ad68e64fac69b77828b76dfc9ac684a8e603cafed00edfe0573d"
+            "sha256": "77d8837cbb2e0cc638c62e559a595d411388168239fa214783c689458db7be86"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -55,6 +55,13 @@
                 "sha256:dc5cab081d4b334d0440b019edf24fe1cb138b8114e0e22d2b0661284bc1775f"
             ],
             "version": "==3.1.1"
+        },
+        "aiomcache": {
+            "hashes": [
+                "sha256:17d82e0586c8500a7a3dac0fdef67e2d0300c82d4acb1595a9925783b7c382b5",
+                "sha256:b38062efca87f2e6ac3b406bd816ca790900b03fef1c5c38fa61c18212c38825"
+            ],
+            "version": "==0.6.0"
         },
         "aioredis": {
             "hashes": [
@@ -135,9 +142,9 @@
         },
         "httptools": {
             "hashes": [
-                "sha256:f50dcb27178416c3a4113e9e1b392be5d1ff56ae1e474fe80869ed8530505e4c"
+                "sha256:04c7703bbef0e8ca28b09811547352b8c7c20549eab70dc24e536bb24fd2b7c5"
             ],
-            "version": "==0.0.10"
+            "version": "==0.0.11"
         },
         "idna": {
             "hashes": [
@@ -449,23 +456,30 @@
         },
         "autopep8": {
             "hashes": [
-                "sha256:c7be71ab0cb2f50c9c22c82f0c9acaafc6f57492c3fbfee9790c415005c2b9a5"
+                "sha256:2284d4ae2052fedb9f466c09728e30d2e231cfded5ffd7b1a20c34123fdc4ba4"
             ],
-            "version": "==1.3.4"
+            "version": "==1.3.5"
         },
         "awscli": {
             "hashes": [
-                "sha256:65145e71fdee88baa197603ad2e361e387ff22b9c86774276101a9c2e4485324",
-                "sha256:e9274cc77dce81d7c45f1850c451336f9b82b8a1d9c02e6cf614806322aab998"
+                "sha256:835e25d0f5806e7b67816883dd2231a806782d609df6966b62830b0d852ee591",
+                "sha256:d8765ac7d969018b2bea79c25a7b264d554bc4955b31219ac1b4f287f8ce968f"
             ],
-            "version": "==1.14.65"
+            "version": "==1.15.0"
+        },
+        "backcall": {
+            "hashes": [
+                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
+                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+            ],
+            "version": "==0.1.0"
         },
         "botocore": {
             "hashes": [
-                "sha256:254803eaca91bf28fa277641039bc06d335faa638862b54454170600a9ed0b5c",
-                "sha256:380272df75f6ee23a18c6b87ab3ad31b91f3c8bf17cc5d0d733a0a0ee72c2c3b"
+                "sha256:3f4d7551775072fb4b8552fc95413894d718ab6dde8ebfd4a3e5888ce19ec091",
+                "sha256:c1611160101e02ac3e6e209473dc7ba8978f9730fe5ba82697771606dabe2d1f"
             ],
-            "version": "==1.9.18"
+            "version": "==1.10.0"
         },
         "cached-property": {
             "hashes": [
@@ -574,9 +588,9 @@
         },
         "httptools": {
             "hashes": [
-                "sha256:f50dcb27178416c3a4113e9e1b392be5d1ff56ae1e474fe80869ed8530505e4c"
+                "sha256:04c7703bbef0e8ca28b09811547352b8c7c20549eab70dc24e536bb24fd2b7c5"
             ],
-            "version": "==0.0.10"
+            "version": "==0.0.11"
         },
         "identify": {
             "hashes": [
@@ -600,10 +614,10 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:51c158a6c8b899898d1c91c6b51a34110196815cc905f9be0fa5878e19355608",
-                "sha256:fcc6d46f08c3c4de7b15ae1c426e15be1b7932bcda9d83ce1a4304e8c1129df3"
+                "sha256:938da96f2f5f50d82add1947958b7432e9f330cef7703210bffd1a783d7720ab",
+                "sha256:c785ab502b1a63624baeb89fedb873a118d4da6c9a796ae06e4f4aaef74e9ea0"
             ],
-            "version": "==6.2.1"
+            "version": "==6.3.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -752,10 +766,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:8b9a7c3704657cb0831b3ded0a6b61377947c8235b76649bb7de4bfe2e6cfa56",
-                "sha256:cf66675e22ae91a4f20e4b8354f117d3e3d1de651513051d109cc39645fb3672"
+                "sha256:56b7a8ba7d64bf6135a9dfefb85a80d95924b3fde5ed6343a1a1d464a040dae3",
+                "sha256:de75cf1d510542c746beeff66b52241eb12c8f95f2ef846ee50ed5d72392caa4"
             ],
-            "version": "==4.0.0"
+            "version": "==4.0.1"
         },
         "pep8": {
             "hashes": [

--- a/jussi/cache/backends/__init__.py
+++ b/jussi/cache/backends/__init__.py
@@ -1,3 +1,2 @@
 # -*- coding: utf-8 -*-
-
 from .max_ttl import SimpleMaxTTLMemoryCache

--- a/jussi/serve.py
+++ b/jussi/serve.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-import argparse
 import os
 
+import configargparse
 from sanic import Sanic
 
 import jussi.errors
@@ -11,7 +11,7 @@ import jussi.logging_config
 import jussi.middlewares
 from jussi.typedefs import WebApp
 
-STEEMIT_MAX_BLOCK_SIZE = 393216000
+STEEMIT_MAX_BLOCK_SIZE = 393_216_000
 REQUEST_MAX_SIZE = STEEMIT_MAX_BLOCK_SIZE + 1000
 
 
@@ -40,46 +40,73 @@ def setup_routes(app: WebApp) -> WebApp:
 def parse_args(args: list = None):
     """parse CLI args and add them to app.config
     """
-    parser = argparse.ArgumentParser(description="jussi reverse proxy server")
+    parser = configargparse.get_argument_parser()
 
     # server config
     parser.add_argument('--debug',
                         type=lambda x: bool(strtobool(x)),
+                        env_var='JUSSI_DEBUG',
                         default=False)
-    parser.add_argument('--server_host', type=str, default='0.0.0.0')
-    parser.add_argument('--server_port', type=int, default=9000)
-    parser.add_argument('--server_workers', type=int, default=os.cpu_count())
-    parser.add_argument('--REQUEST_MAX_SIZE', type=int,
-                        default=REQUEST_MAX_SIZE)
-    parser.add_argument('--REQUEST_TIMEOUT', type=int, default=5)
-    parser.add_argument('--KEEP_ALIVE', type=bool, default=True)
+    parser.add_argument('--server_host', type=str, env_var='JUSSI_SERVER_HOST',
+                        default='0.0.0.0')
+    parser.add_argument('--server_port', type=int, env_var='JUSSI_SERVER_PORT',
+                        default=9000)
+    parser.add_argument('--server_workers', type=int,
+                        env_var='JUSSI_SERVER_WORKERS', default=os.cpu_count())
+    parser.add_argument('--REQUEST_MAX_SIZE', env_var='JUSSI_REQUEST_MAX_SIZE',
+                        type=int,
+                        default=6_000_000)
+    parser.add_argument('--REQUEST_TIMEOUT', type=int,
+                        env_var='JUSSI_REQUEST_TIMEOU?T', default=5)
+    parser.add_argument('--KEEP_ALIVE', type=lambda x: bool(strtobool(x)),
+                        env_var='JUSSI_KEEP_ALIVE', default=True)
 
     # server websocket pool config
-    parser.add_argument('--websocket_pool_minsize', type=int, default=0)
-    parser.add_argument('--websocket_pool_maxsize', type=int, default=5)
-    parser.add_argument('--websocket_queue_size', type=int, default=1)
-    parser.add_argument('--websocket_pool_recycle', type=int, default=-1)
+    parser.add_argument('--websocket_pool_minsize', type=int,
+                        env_var='JUSSI_WEBSOCKET_POOL_MINSIZE', default=8)
+    parser.add_argument('--websocket_pool_maxsize',
+                        env_var='JUSSI_WEBSOCKET_POOL_MAXSIZE', type=int,
+                        default=8)
+    parser.add_argument('--websocket_queue_size',
+                        env_var='JUSSI_WEBSOCKET_QUEUE', type=int, default=1)
+    parser.add_argument('--websocket_pool_recycle',
+                        env_var='JUSSI_WEBSOCKET_POOL_RECYCLE', type=int,
+                        default=-1)
 
     # server version
-    parser.add_argument('--source_commit', type=str, default='')
-    parser.add_argument('--docker_tag', type=str, default='')
+    parser.add_argument('--source_commit', env_var='SOURCE_COMMIT', type=str,
+                        default='')
+    parser.add_argument('--docker_tag', type=str, env_var='DOCKER_TAG',
+                        default='')
 
     # upstream config
     parser.add_argument('--upstream_config_file', type=str,
+                        env_var='JUSSI_UPSTREAM_CONFIG_FILE',
                         default='PROD_UPSTREAM_CONFIG.json')
     parser.add_argument('--test_upstream_urls',
+                        env_var='JUSSI_TEST_UPSTREAM_URLS',
                         type=lambda x: bool(strtobool(x)),
                         default=True)
 
     # cache config (applies to all caches
-    parser.add_argument('--cache_read_timeout', type=float, default=1.0)
+    parser.add_argument('--cache_read_timeout', type=float,
+                        env_var='JUSSI_CACHE_READ_TIMEOUT', default=1.0)
+    parser.add_argument('--cache_test_before_add',
+                        type=lambda x: bool(strtobool(x)),
+                        env_var='JUSSI_CACHE_TEST_BEFORE_ADD', default=False)
 
     # redis config
-    parser.add_argument('--redis_host', type=str, default=None)
-    parser.add_argument('--redis_port', type=int, default=6379)
-    parser.add_argument('--redis_pool_minsize', type=int, default=1)
-    parser.add_argument('--redis_pool_maxsize', type=int, default=10)
-    parser.add_argument('--redis_read_replica_hosts', type=str, default=None, nargs='*')
+    parser.add_argument('--redis_host', type=str, env_var='JUSSI_REDIS_HOST',
+                        default=None)
+    parser.add_argument('--redis_port', type=int, env_var='JUSSI_REDIS_PORT',
+                        default=6379)
+    parser.add_argument('--redis_pool_minsize', type=int,
+                        env_var='JUSSI_REDIS_POOL_MINSIZE', default=1)
+    parser.add_argument('--redis_pool_maxsize', type=int,
+                        env_var='JUSSI_REDIS_POOL_MAXSIZE', default=10)
+    parser.add_argument('--redis_read_replica_hosts', type=str,
+                        env_var='JUSSI_REDIS_READ_REPLICA_HOSTS', default=None,
+                        nargs='*')
 
     return parser.parse_args(args=args)
 

--- a/service/jussi/run
+++ b/service/jussi/run
@@ -1,31 +1,6 @@
 #!/bin/bash -e
 
-
-CPU_COUNT="$(grep -c processor /proc/cpuinfo)"
-
-
 cd "${APP_ROOT}"
 exec 2>&1 \
   chpst -u www-data \
-    pipenv run python3.6 -m "${APP_CMD}" \
-      --debug "${JUSSI_DEBUG:-False}" \
-      --server_host "${JUSSI_SERVER_HOST}" \
-      --server_port "${JUSSI_SERVER_PORT}" \
-      --server_workers "${JUSSI_SERVER_WORKERS:-$CPU_COUNT}" \
-      --REQUEST_MAX_SIZE "${JUSSI_REQUEST_MAX_SIZE:-6_000_000}" \
-      --REQUEST_TIMEOUT "${JUSSI_REQUEST_TIMEOUT:- 11}" \
-      --KEEP_ALIVE "${JUSSI_KEEP_ALIVE:-True}" \
-      --websocket_pool_minsize "${JUSSI_WEBSOCKET_POOL_MINSIZE:-8}" \
-      --websocket_pool_maxsize "${JUSSI_WEBSOCKET_POOL_MAXSIZE:-8}" \
-      --websocket_pool_recycle "${JUSSI_WESOCKET_POOL_RECYCLE:- -1}" \
-      --websocket_queue_size "${JUSSI_WESOCKET_QUEUE_SIZE:- 0}" \
-      --source_commit "${SOURCE_COMMIT}" \
-      --docker_tag "${DOCKER_TAG}" \
-      --upstream_config_file "${JUSSI_UPSTREAM_CONFIG_FILE:- PROD_UPSTREAM_CONFIG.json}" \
-      --test_upstream_urls "${JUSSI_TEST_UPSTREAM_URLS:- True}" \
-      --cache_read_timeout "${JUSSI_CACHE_READ_TIMEOUT:-1.0}" \
-      --redis_host "${JUSSI_REDIS_HOST}" \
-      --redis_port "${JUSSI_REDIS_PORT:-6379}" \
-      --redis_pool_minsize "${JUSSI_REDIS_POOL_MINSIZE:-1}" \
-      --redis_pool_maxsize "${JUSSI_REDIS_POOL_MAXSIZE:-10}" \
-      --redis_read_replica_hosts "${JUSSI_REDIS_READ_REPLICA_HOSTS}"
+    pipenv run python3.6 -m "${APP_CMD}"


### PR DESCRIPTION
Closes #133 Duplicate cli configuration and defaults

In addition to fixing the bug a cache configuration bug, I removed the second set of cli defaults from the runnit service, so that all config now comes either from env vars or the python command invocation