### PR TITLE
change jussi validator to check for length of 8192 bytes instead of 2000 characters

### DIFF
--- a/jussi/validators.py
+++ b/jussi/validators.py
@@ -34,7 +34,7 @@ NONE_TYPE = type(None)
 ID_TYPES = (int, str, float, NONE_TYPE)
 PARAMS_TYPES = (list, dict, NONE_TYPE)
 
-CUSTOM_JSON_SIZE_LIMIT = 2000
+CUSTOM_JSON_SIZE_LIMIT = 8192
 CUSTOM_JSON_FOLLOW_RATE = 2
 
 BROADCAST_TRANSACTION_METHODS = {
@@ -199,7 +199,7 @@ def limit_broadcast_transaction_request(request: JSONRPCRequest, limits=None) ->
 
 
 def limit_custom_json_op_length(ops: list, size_limit=None):
-    if any(len(op[1]['json']) > size_limit for op in ops):
+    if any(len(op[1]['json'].encode('utf-8')) > size_limit for op in ops):
         raise JussiCustomJsonOpLengthError(size_limit=size_limit)
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -294,7 +294,16 @@ def test_is_valid_jussi_response_using_steemd(steemd_request_and_response):
         {
             "required_auths": [],
             "id": "follow",
-            "json": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "json": "a"*8192,
+            "required_posting_auths": ["steemit"]
+        }
+    ]], False),
+    ([[
+        'custom_json',
+        {
+            "required_auths": [],
+            "id": "follow",
+            "json": "😂"*2048,
             "required_posting_auths": ["steemit"]
         }
     ]], False),
@@ -302,9 +311,9 @@ def test_is_valid_jussi_response_using_steemd(steemd_request_and_response):
 def test_is_valid_custom_json_op_length(ops, expected):
     if expected is False:
         with pytest.raises(JussiCustomJsonOpLengthError):
-            limit_custom_json_op_length(ops, size_limit=1000)
+            limit_custom_json_op_length(ops, size_limit=8191)
     else:
-        limit_custom_json_op_length(ops, size_limit=1000)
+        limit_custom_json_op_length(ops, size_limit=100)
 
 
 @pytest.mark.parametrize('ops, expected', [


### PR DESCRIPTION
closes #221 

- added a test case that uses 2048 (8192 bytes) emojis to verify custom_json max size.
- edited a test case to check for a small max byte size.