### PR TITLE
Dont cache irreversible blocks forever

### DIFF
--- a/jussi/cache/cache_group.py
+++ b/jussi/cache/cache_group.py
@@ -33,7 +33,7 @@ from .utils import merge_cached_responses
 
 logger = structlog.getLogger(__name__)
 
-BATCH_IRREVERSIBLE_TTL_SET = frozenset([TTL.NO_EXPIRE_IF_IRREVERSIBLE])
+BATCH_IRREVERSIBLE_TTL_SET = frozenset([TTL.DEFAULT_EXPIRE_IF_IRREVERSIBLE])
 
 # types
 CacheTTLValue = TypeVar('CacheTTL', int, float, type(None))
@@ -188,7 +188,7 @@ class CacheGroup:
                                             ) -> None:
         key = jsonrpc_cache_key(request)
         ttl = ttl or request.upstream.ttl
-        if ttl == TTL.NO_EXPIRE_IF_IRREVERSIBLE:
+        if ttl == TTL.DEFAULT_EXPIRE_IF_IRREVERSIBLE:
             last_irreversible_block_num = last_irreversible_block_num or \
                 self._memory_cache.gets('last_irreversible_block_num') or \
                 await self.get('last_irreversible_block_num')
@@ -218,7 +218,7 @@ class CacheGroup:
         else:
             new_ttls = []
             for i, ttl in enumerate(ttls):
-                if ttl == TTL.NO_EXPIRE_IF_IRREVERSIBLE:
+                if ttl == TTL.DEFAULT_EXPIRE_IF_IRREVERSIBLE:
                     ttl = irreversible_ttl(responses[i], last_irreversible_block_num)
                 new_ttls.append(ttl)
             triplets = filter(lambda p: p[0] != TTL.NO_CACHE, zip(ttls, requests, responses))

--- a/jussi/cache/ttl.py
+++ b/jussi/cache/ttl.py
@@ -8,11 +8,11 @@ Method Settings
 - TTL is an integer value in seconds. Integers <= 0 have special meaning
   - A TTL of `0` won't expire
   - A TTL of `-1` wont be cached
-  - A TTL of `-2` will be cached without expiration only if it is 'irreversible' in terms of blockchain consesus
+  - A TTL of `-2` will be cached with default expiration only if it is 'irreversible' in terms of blockchain consesus
 - For readabilty/writabilty, there are shorthand variables for these 'special' TTL values:
    - `NO_EXPIRE` == 0
    - `NO_CACHE` == -1
-   - `NO_EXPIRE_IF_IRREVERSIBLE` == -2
+   - `DEFAULT_EXPIRE_IF_IRREVERSIBLE` == -2
 
 """
 
@@ -23,7 +23,7 @@ class TTL(Enum):
     DEFAULT_TTL = 3
     NO_EXPIRE = None
     NO_CACHE = -1
-    NO_EXPIRE_IF_IRREVERSIBLE = -2
+    DEFAULT_EXPIRE_IF_IRREVERSIBLE = -2
 
     # pylint: disable=no-else-return
     def __eq__(self, other: int) -> bool:

--- a/jussi/cache/utils.py
+++ b/jussi/cache/utils.py
@@ -31,7 +31,7 @@ def irreversible_ttl(jsonrpc_response: dict=None,
     try:
         jrpc_block_num = block_num_from_jsonrpc_response(jsonrpc_response)
         if jrpc_block_num and jrpc_block_num <= last_irreversible_block_num:
-            return TTL.NO_EXPIRE
+            return TTL.DEFAULT_TTL
         return TTL.DEFAULT_TTL
     except Exception as e:
         logger.warning(

--- a/jussi/cache/utils.py
+++ b/jussi/cache/utils.py
@@ -30,8 +30,6 @@ def irreversible_ttl(jsonrpc_response: dict=None,
         return TTL.NO_CACHE
     try:
         jrpc_block_num = block_num_from_jsonrpc_response(jsonrpc_response)
-        if jrpc_block_num and jrpc_block_num <= last_irreversible_block_num:
-            return TTL.DEFAULT_TTL
         return TTL.DEFAULT_TTL
     except Exception as e:
         logger.warning(

--- a/tests/test_ttls.py
+++ b/tests/test_ttls.py
@@ -54,7 +54,7 @@ def test_ttls(rpc_req, rpc_resp, last_block_num, expected):
     (TTL.NO_CACHE, -1),
     (TTL.DEFAULT_TTL, 3),
     (TTL.NO_EXPIRE, None),
-    (TTL.NO_EXPIRE_IF_IRREVERSIBLE, -2),
+    (TTL.DEFAULT_EXPIRE_IF_IRREVERSIBLE, -2),
 ]
 )
 def test_ttl_eq(ttl, eq):
@@ -65,7 +65,7 @@ def test_ttl_eq(ttl, eq):
 @pytest.mark.parametrize('ttl', [
     (TTL.NO_CACHE),
     (TTL.DEFAULT_TTL),
-    (TTL.NO_EXPIRE_IF_IRREVERSIBLE)
+    (TTL.DEFAULT_EXPIRE_IF_IRREVERSIBLE)
 ]
 )
 def test_ttl_gt(ttl):
@@ -75,7 +75,7 @@ def test_ttl_gt(ttl):
 @pytest.mark.parametrize('ttl', [
     (TTL.NO_CACHE),
     (TTL.DEFAULT_TTL),
-    (TTL.NO_EXPIRE_IF_IRREVERSIBLE)
+    (TTL.DEFAULT_EXPIRE_IF_IRREVERSIBLE)
 ]
 )
 def test_ttl_ge(ttl):
@@ -85,7 +85,7 @@ def test_ttl_ge(ttl):
 @pytest.mark.parametrize('ttl', [
     (TTL.NO_CACHE),
     (TTL.DEFAULT_TTL),
-    (TTL.NO_EXPIRE_IF_IRREVERSIBLE)
+    (TTL.DEFAULT_EXPIRE_IF_IRREVERSIBLE)
 ]
 )
 def test_ttl_lt(ttl):
@@ -95,7 +95,7 @@ def test_ttl_lt(ttl):
 @pytest.mark.parametrize('ttl', [
     (TTL.NO_CACHE),
     (TTL.DEFAULT_TTL),
-    (TTL.NO_EXPIRE_IF_IRREVERSIBLE)
+    (TTL.DEFAULT_EXPIRE_IF_IRREVERSIBLE)
 ]
 )
 def test_ttl_le(ttl):

--- a/tests/test_ttls.py
+++ b/tests/test_ttls.py
@@ -35,8 +35,8 @@ non_ttl_rpc_req = jsonrpc_from_request(dummy_request, 0, {"id": "1", "jsonrpc": 
     (ttl_rpc_req, rpc_resp, 999, TTL.DEFAULT_TTL),
 
     # cache when last_block_num >= response block_num
-    (ttl_rpc_req, rpc_resp, 1000, TTL.NO_EXPIRE),
-    (ttl_rpc_req, rpc_resp, 1001, TTL.NO_EXPIRE),
+    (ttl_rpc_req, rpc_resp, 1000, TTL.DEFAULT_TTL),
+    (ttl_rpc_req, rpc_resp, 1001, TTL.DEFAULT_TTL),
 
     # don't cache when bad/missing response block_num
     (ttl_rpc_req, {}, 2000, TTL.NO_CACHE),


### PR DESCRIPTION
When Jussi was originally designed, steemd was very slow at responding to requests and all requests would block the web server process. To mitigate this, part of the design goal for jussi was to cache all irreversible blocks for all of eternity. At the time, this was correct and desired behvaior as the goal was to push as much request load onto jussi as possible and alleviate steemd from requests that it did not have to serve.

Now that appbase is a reality, steemd can handle these requests very efficiently without each request blocking the whole process. Further, MIRA makes it much less costly to run additional steemd's in order to handle more load if necessary. Because of these two reasons, it is now more expensive and unnecessary to have jussi handle all irreversible blocks than having steemd handle them (except for the default caching behvaior in jussi).

This change causes jussi to cache irreversible blocks for the default TTL (which is currently 3 seconds) - the behavior for still reversible blocks is the same (no cache).