### PR TITLE
Regex match on /proposals to route to steemd

### DIFF
--- a/jussi/upstream.py
+++ b/jussi/upstream.py
@@ -18,7 +18,7 @@ from .errors import InvalidUpstreamURL
 
 logger = structlog.get_logger(__name__)
 
-ACCOUNT_TRANSFER_PATTERN = re.compile(r'^\/?(@([^\/\s]+)/transfers|~?witnesses)$')
+ACCOUNT_TRANSFER_PATTERN = re.compile(r'^\/?(@([^\/\s]+)/transfers|~?witnesses|proposals)$')
 
 
 # -------------------


### PR DESCRIPTION
Just like we do with the witnesses page, we need to route get_state(/proposals) to a steemd instead of hivemind. Even though get_state(/proposals) isn't a thing, condenser still calls this (since it calls get_state on every route).