### PR TITLE
fix: set max_connections=20 on Redis connection pools

### DIFF
--- a/jussi/cache/__init__.py
+++ b/jussi/cache/__init__.py
@@ -8,6 +8,7 @@ from enum import IntEnum
 import structlog
 
 from aredis import StrictRedis
+from aredis import ConnectionPool
 
 
 from .cache_group import CacheGroup
@@ -33,7 +34,9 @@ def setup_caches(app: WebApp, loop) -> Any:
     caches = []
     if args.redis_url:
         try:
-            redis_client = StrictRedis().from_url(args.redis_url)
+            pool = ConnectionPool.from_url(args.redis_url,
+                                            max_connections=20)
+            redis_client = StrictRedis(connection_pool=pool)
             redis_cache = Cache(redis_client)
             if redis_cache:
                 caches.append(CacheGroupItem(cache=redis_cache,
@@ -49,7 +52,9 @@ def setup_caches(app: WebApp, loop) -> Any:
                             read_replica=url,
                             host=url.hostname,
                             port=url.port)
-                redis_client = StrictRedis().from_url(url_string)
+                replica_pool = ConnectionPool.from_url(url_string,
+                                                       max_connections=20)
+                redis_client = StrictRedis(connection_pool=replica_pool)
                 redis_cache = Cache(redis_client)
                 if redis_cache:
                     caches.append(


### PR DESCRIPTION
aredis ConnectionPool defaults max_connections to 2^31 (effectively unlimited), causing ~2960 connections across 7 instances x 2 pools. Set explicit max_connections=20 per pool to cap total at ~315.