### PR TITLE
feat(errors): add request_data and client_ip to UpstreamResponseError logs

### DIFF
--- a/jussi/errors.py
+++ b/jussi/errors.py
@@ -302,6 +302,34 @@ class UpstreamResponseError(JsonRpcError):
     code = 1100
     message = 'Upstream response error: {reason}'
 
+    def to_dict(self):
+        data = super().to_dict()
+        # include the user's JSON-RPC request data for diagnosis
+        try:
+            if self.jsonrpc_request:
+                data['request_data'] = self.jsonrpc_request.to_dict()
+        except Exception:
+            pass
+        # include the real client IP for openresty blocking.
+        # openresty's real_ip_header already restores the true client IP
+        # to $remote_addr, then passes it as X-Real-IP to jussi.
+        # X-Forwarded-For ($proxy_add_x_forwarded_for) contains the full
+        # proxy chain and is used as fallback.
+        try:
+            if self.http_request:
+                xri = self.http_request.headers.get('X-Real-IP', '')
+                if xri:
+                    data['client_ip'] = xri
+                else:
+                    xff = self.http_request.headers.get('X-Forwarded-For', '')
+                    if xff:
+                        data['client_ip'] = xff.split(',')[0].strip()
+                    else:
+                        data['client_ip'] = getattr(self.http_request, 'ip', 'unknown')
+        except Exception:
+            pass
+        return data
+
 
 class InvalidNamespaceError(JsonRpcError):
     code = 1200


### PR DESCRIPTION
## Summary

When upstream returns invalid JSON, the Scalyr error log now includes:
- `request_data`: the user's JSON-RPC request (method, params, id)
- `client_ip`: the real client IP for targeted openresty blocking

## Details

`UpstreamResponseError.to_dict()` now extracts:
1. **request_data** from `jrpc_request.to_dict()` — shows exactly what method/params triggered the upstream error
2. **client_ip** from headers, with priority: `X-Real-IP` (set by openresty after `real_ip_header` processing) → `X-Forwarded-For` (first hop) → `http_request.ip`

## Why

Previously the error log showed:
```
Upstream response error: upstream returned invalid JSON: ValueError(...)
```

With no way to tell which request caused it or who sent it.

Now operators can:
- Search Scalyr by `client_ip` to find abusive sources
- See the exact `method` and `params` that triggered the error
- Add targeted IP blocks in openresty

## Test Plan

- [x] Syntax check passes
- [ ] Deploy to dev-jussi and verify log format