### PR TITLE
fix: translate legacy database_api to condenser_api before routing

### DIFF
--- a/internal/handlers/processor.go
+++ b/internal/handlers/processor.go
@@ -51,6 +51,30 @@ func NewRequestProcessor(
 	}
 }
 
+// legacyAPIs maps old-style API namespaces that must be translated to
+// condenser_api for steemd 0.23.x+ appbase compatibility.
+// These methods (e.g. database_api.get_state) are legacy and will be
+// removed in future steemd versions; condenser_api provides backward
+// compatibility in the meantime.
+var legacyAPIs = map[string]bool{
+	"database_api": true,
+}
+
+// translateLegacyAPI translates old-style API methods (e.g. database_api.get_state)
+// to their condenser_api equivalents. This must run before routing so the URN
+// matches the correct upstream entry in config (e.g. appbase.condenser_api.get_state → hivemind).
+func translateLegacyAPI(jsonrpcReq *request.JSONRPCRequest) {
+	if !legacyAPIs[jsonrpcReq.URN.API] {
+		return
+	}
+
+	oldAPI := jsonrpcReq.URN.API
+	jsonrpcReq.URN.API = "condenser_api"
+
+	// "database_api.get_state" → "condenser_api.get_state"
+	jsonrpcReq.Method = strings.Replace(jsonrpcReq.Method, oldAPI+".", "condenser_api.", 1)
+}
+
 // ProcessSingleRequest processes a single JSON-RPC request
 func (p *RequestProcessor) ProcessSingleRequest(ctx context.Context, jsonrpcReq *request.JSONRPCRequest) (map[string]interface{}, error) {
 	// Create span for request processing
@@ -58,6 +82,10 @@ func (p *RequestProcessor) ProcessSingleRequest(ctx context.Context, jsonrpcReq 
 		trace.WithSpanKind(trace.SpanKindInternal),
 	)
 	defer span.End()
+
+	// Translate legacy API methods (e.g. database_api.get_state → condenser_api.get_state)
+	// before routing so the URN matches the correct upstream config entry.
+	translateLegacyAPI(jsonrpcReq)
 
 	// Add span attributes
 	telemetry.AddSpanAttributes(span, map[string]string{

--- a/internal/handlers/processor.go
+++ b/internal/handlers/processor.go
@@ -63,6 +63,12 @@ var legacyAPIs = map[string]bool{
 // translateLegacyAPI translates old-style API methods (e.g. database_api.get_state)
 // to their condenser_api equivalents. This must run before routing so the URN
 // matches the correct upstream entry in config (e.g. appbase.condenser_api.get_state → hivemind).
+//
+// Two request formats are handled:
+//  1. call-style: method="call", params=["database_api","get_state",args]
+//     → translate params[0] to "condenser_api" so the upstream receives the appbase method
+//  2. direct method: method="database_api.get_state", params=args
+//     → translate the method string to "condenser_api.get_state"
 func translateLegacyAPI(jsonrpcReq *request.JSONRPCRequest) {
 	if !legacyAPIs[jsonrpcReq.URN.API] {
 		return
@@ -70,9 +76,23 @@ func translateLegacyAPI(jsonrpcReq *request.JSONRPCRequest) {
 
 	oldAPI := jsonrpcReq.URN.API
 	jsonrpcReq.URN.API = "condenser_api"
+	// Switch namespace to "appbase" so routing matches config entries
+	// like "appbase.condenser_api.get_state" instead of falling through
+	// the "steemd" namespace to the generic steemd upstream.
+	jsonrpcReq.URN.Namespace = "appbase"
 
-	// "database_api.get_state" → "condenser_api.get_state"
-	jsonrpcReq.Method = strings.Replace(jsonrpcReq.Method, oldAPI+".", "condenser_api.", 1)
+	if jsonrpcReq.Method == "call" {
+		// call-style: params=[api_name, method_name, args]
+		// Translate params[0] from "database_api" to "condenser_api"
+		if paramsSlice, ok := jsonrpcReq.Params.([]interface{}); ok && len(paramsSlice) >= 1 {
+			if apiName, ok := paramsSlice[0].(string); ok && apiName == oldAPI {
+				paramsSlice[0] = "condenser_api"
+			}
+		}
+	} else {
+		// Direct method: "database_api.get_state" → "condenser_api.get_state"
+		jsonrpcReq.Method = strings.Replace(jsonrpcReq.Method, oldAPI+".", "condenser_api.", 1)
+	}
 }
 
 // ProcessSingleRequest processes a single JSON-RPC request

--- a/internal/handlers/processor_translate_test.go
+++ b/internal/handlers/processor_translate_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/steemit/jussi/internal/urn"
 )
 
-func TestTranslateLegacyAPI_databaseAPI(t *testing.T) {
+func TestTranslateLegacyAPI_directMethod(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputAPI       string
@@ -65,12 +65,106 @@ func TestTranslateLegacyAPI_databaseAPI(t *testing.T) {
 			if req.Method != tt.expectedMethod {
 				t.Errorf("Method = %q, want %q", req.Method, tt.expectedMethod)
 			}
+			if req.URN.Namespace != "appbase" {
+				t.Errorf("URN.Namespace = %q, want %q", req.URN.Namespace, "appbase")
+			}
 		})
 	}
 }
 
+func TestTranslateLegacyAPI_callStyle(t *testing.T) {
+	tests := []struct {
+		name           string
+		params         []interface{}
+		expectedParam0 string
+	}{
+		{
+			name:           "call get_state",
+			params:         []interface{}{"database_api", "get_state", []interface{}{"/trending"}},
+			expectedParam0: "condenser_api",
+		},
+		{
+			name:           "call get_dynamic_global_properties",
+			params:         []interface{}{"database_api", "get_dynamic_global_properties", []interface{}{}},
+			expectedParam0: "condenser_api",
+		},
+		{
+			name:           "call get_block",
+			params:         []interface{}{"database_api", "get_block", []interface{}{106191898}},
+			expectedParam0: "condenser_api",
+		},
+		{
+			name:           "call get_account_history",
+			params:         []interface{}{"database_api", "get_account_history", []interface{}{"user", -1, 20}},
+			expectedParam0: "condenser_api",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &request.JSONRPCRequest{
+				Method: "call",
+				Params: tt.params,
+				URN: &urn.URN{
+					Namespace: "steemd",
+					API:       "database_api",
+					Method:    tt.params[1].(string),
+				},
+			}
+
+			translateLegacyAPI(req)
+
+			// Method should remain "call"
+			if req.Method != "call" {
+				t.Errorf("Method = %q, want %q", req.Method, "call")
+			}
+			// URN should be translated
+			if req.URN.API != "condenser_api" {
+				t.Errorf("URN.API = %q, want %q", req.URN.API, "condenser_api")
+			}
+			if req.URN.Namespace != "appbase" {
+				t.Errorf("URN.Namespace = %q, want %q", req.URN.Namespace, "appbase")
+			}
+			// params[0] should be translated
+			paramsSlice, ok := req.Params.([]interface{})
+			if !ok {
+				t.Fatal("Params should be []interface{}")
+			}
+			if paramsSlice[0] != tt.expectedParam0 {
+				t.Errorf("Params[0] = %q, want %q", paramsSlice[0], tt.expectedParam0)
+			}
+		})
+	}
+}
+
+func TestTranslateLegacyAPI_callStyle_preservesMethodAndArgs(t *testing.T) {
+	// Verify that params[1] (method name) and params[2] (args) are unchanged
+	req := &request.JSONRPCRequest{
+		Method: "call",
+		Params: []interface{}{"database_api", "get_state", []interface{}{"/@test/transfers"}},
+		URN: &urn.URN{
+			Namespace: "steemd",
+			API:       "database_api",
+			Method:    "get_state",
+		},
+	}
+
+	translateLegacyAPI(req)
+
+	paramsSlice := req.Params.([]interface{})
+	if paramsSlice[1] != "get_state" {
+		t.Errorf("Params[1] = %q, want %q", paramsSlice[1], "get_state")
+	}
+	args, ok := paramsSlice[2].([]interface{})
+	if !ok {
+		t.Fatal("Params[2] should be []interface{}")
+	}
+	if args[0] != "/@test/transfers" {
+		t.Errorf("Params[2][0] = %q, want %q", args[0], "/@test/transfers")
+	}
+}
+
 func TestTranslateLegacyAPI_nonLegacyAPI(t *testing.T) {
-	// Non-legacy APIs should not be translated
 	req := &request.JSONRPCRequest{
 		Method: "condenser_api.get_state",
 		URN: &urn.URN{
@@ -91,7 +185,6 @@ func TestTranslateLegacyAPI_nonLegacyAPI(t *testing.T) {
 }
 
 func TestTranslateLegacyAPI_followAPI(t *testing.T) {
-	// follow_api is NOT a legacy API, should not be translated
 	req := &request.JSONRPCRequest{
 		Method: "follow_api.get_blog",
 		URN: &urn.URN{
@@ -109,7 +202,6 @@ func TestTranslateLegacyAPI_followAPI(t *testing.T) {
 }
 
 func TestTranslateLegacyAPI_urnString(t *testing.T) {
-	// Verify the URN string is correct after translation for routing purposes
 	req := &request.JSONRPCRequest{
 		Method: "database_api.get_state",
 		URN: &urn.URN{
@@ -123,13 +215,38 @@ func TestTranslateLegacyAPI_urnString(t *testing.T) {
 	translateLegacyAPI(req)
 
 	expectedURN := "appbase.condenser_api.get_state"
-	// URN.String() with params appends params=..., so check prefix
 	if req.URN.API != "condenser_api" {
 		t.Errorf("URN.API = %q, want %q", req.URN.API, "condenser_api")
 	}
-	// The URN string should start with the expected prefix for routing
+	if req.URN.Namespace != "appbase" {
+		t.Errorf("URN.Namespace = %q, want %q", req.URN.Namespace, "appbase")
+	}
 	urnStr := req.URN.String()
 	if !strings.HasPrefix(urnStr, expectedURN) {
 		t.Errorf("URN.String() = %q, want prefix %q", urnStr, expectedURN)
+	}
+}
+
+func TestTranslateLegacyAPI_callStyle_namespaceSwitch(t *testing.T) {
+	// Verify that steemd namespace is switched to appbase for correct routing
+	req := &request.JSONRPCRequest{
+		Method: "call",
+		Params: []interface{}{"database_api", "get_state", []interface{}{"/@user/transfers"}},
+		URN: &urn.URN{
+			Namespace: "steemd",
+			API:       "database_api",
+			Method:    "get_state",
+		},
+	}
+
+	translateLegacyAPI(req)
+
+	if req.URN.Namespace != "appbase" {
+		t.Errorf("URN.Namespace = %q, want %q (appbase for routing to hivemind)", req.URN.Namespace, "appbase")
+	}
+	urnStr := req.URN.String()
+	expectedPrefix := "appbase.condenser_api.get_state"
+	if !strings.HasPrefix(urnStr, expectedPrefix) {
+		t.Errorf("URN.String() = %q, want prefix %q", urnStr, expectedPrefix)
 	}
 }

--- a/internal/handlers/processor_translate_test.go
+++ b/internal/handlers/processor_translate_test.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steemit/jussi/internal/request"
+	"github.com/steemit/jussi/internal/urn"
+)
+
+func TestTranslateLegacyAPI_databaseAPI(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputAPI       string
+		inputMethod    string
+		expectedAPI    string
+		expectedMethod string
+	}{
+		{
+			name:           "database_api.get_state → condenser_api.get_state",
+			inputAPI:       "database_api",
+			inputMethod:    "database_api.get_state",
+			expectedAPI:    "condenser_api",
+			expectedMethod: "condenser_api.get_state",
+		},
+		{
+			name:           "database_api.get_dynamic_global_properties",
+			inputAPI:       "database_api",
+			inputMethod:    "database_api.get_dynamic_global_properties",
+			expectedAPI:    "condenser_api",
+			expectedMethod: "condenser_api.get_dynamic_global_properties",
+		},
+		{
+			name:           "database_api.get_block",
+			inputAPI:       "database_api",
+			inputMethod:    "database_api.get_block",
+			expectedAPI:    "condenser_api",
+			expectedMethod: "condenser_api.get_block",
+		},
+		{
+			name:           "database_api.get_account_history",
+			inputAPI:       "database_api",
+			inputMethod:    "database_api.get_account_history",
+			expectedAPI:    "condenser_api",
+			expectedMethod: "condenser_api.get_account_history",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &request.JSONRPCRequest{
+				Method: tt.inputMethod,
+				URN: &urn.URN{
+					Namespace: "appbase",
+					API:       tt.inputAPI,
+					Method:    tt.inputMethod[strings.Index(tt.inputMethod, ".")+1:],
+				},
+			}
+
+			translateLegacyAPI(req)
+
+			if req.URN.API != tt.expectedAPI {
+				t.Errorf("URN.API = %q, want %q", req.URN.API, tt.expectedAPI)
+			}
+			if req.Method != tt.expectedMethod {
+				t.Errorf("Method = %q, want %q", req.Method, tt.expectedMethod)
+			}
+		})
+	}
+}
+
+func TestTranslateLegacyAPI_nonLegacyAPI(t *testing.T) {
+	// Non-legacy APIs should not be translated
+	req := &request.JSONRPCRequest{
+		Method: "condenser_api.get_state",
+		URN: &urn.URN{
+			Namespace: "appbase",
+			API:       "condenser_api",
+			Method:    "get_state",
+		},
+	}
+
+	translateLegacyAPI(req)
+
+	if req.URN.API != "condenser_api" {
+		t.Errorf("URN.API should remain %q, got %q", "condenser_api", req.URN.API)
+	}
+	if req.Method != "condenser_api.get_state" {
+		t.Errorf("Method should remain unchanged, got %q", req.Method)
+	}
+}
+
+func TestTranslateLegacyAPI_followAPI(t *testing.T) {
+	// follow_api is NOT a legacy API, should not be translated
+	req := &request.JSONRPCRequest{
+		Method: "follow_api.get_blog",
+		URN: &urn.URN{
+			Namespace: "appbase",
+			API:       "follow_api",
+			Method:    "get_blog",
+		},
+	}
+
+	translateLegacyAPI(req)
+
+	if req.URN.API != "follow_api" {
+		t.Errorf("URN.API should remain %q, got %q", "follow_api", req.URN.API)
+	}
+}
+
+func TestTranslateLegacyAPI_urnString(t *testing.T) {
+	// Verify the URN string is correct after translation for routing purposes
+	req := &request.JSONRPCRequest{
+		Method: "database_api.get_state",
+		URN: &urn.URN{
+			Namespace: "appbase",
+			API:       "database_api",
+			Method:    "get_state",
+			Params:    []interface{}{"/trending"},
+		},
+	}
+
+	translateLegacyAPI(req)
+
+	expectedURN := "appbase.condenser_api.get_state"
+	// URN.String() with params appends params=..., so check prefix
+	if req.URN.API != "condenser_api" {
+		t.Errorf("URN.API = %q, want %q", req.URN.API, "condenser_api")
+	}
+	// The URN string should start with the expected prefix for routing
+	urnStr := req.URN.String()
+	if !strings.HasPrefix(urnStr, expectedURN) {
+		t.Errorf("URN.String() = %q, want prefix %q", urnStr, expectedURN)
+	}
+}


### PR DESCRIPTION
## Summary

- Go jussi (next) was forwarding old-style `database_api.*` methods as-is to upstream backends, causing ~50% of condenser requests to fail because steemd 0.23.x only accepts appbase-format `condenser_api.*` calls
- Added `translateLegacyAPI()` in processor that converts `database_api.X → condenser_api.X` before routing, so the URN matches config entries like `appbase.condenser_api.get_state` (→ hivemind) instead of falling back to generic `appbase → steemd` where the old method is rejected
- `database_api` methods are **legacy** and will be removed in future steemd versions; `condenser_api` provides backward compatibility

### Root cause (from Jaeger traces on dev)

| Error | 24h count | Method | Cause |
|-------|-----------|--------|-------|
| Could not find method get_state | 32x | `database_api.get_state` | steemd 0.23.x doesn't support old-style method |
| Bad Cast: array_type to Object | 20x | `database_api.get_dynamic_global_properties` | params format mismatch without translation |
| Could not find method get_block | 8x | `database_api.get_block` | same as get_state |
| Could not find method get_account_history | 6x | `database_api.get_account_history` | same as get_state |
| Invalid parameters | 4x | `follow_api.get_blog` | condenser frontend bug (separate issue) |

`steemit-dev-condenser-001` was reporting **Red/Degraded** with 43-46% HTTP 4xx + 4-8% HTTP 5xx.

## Test plan

- [x] Unit tests for `translateLegacyAPI()` — 4 legacy translation cases + 2 non-legacy guard cases + URN string verification
- [x] All existing tests pass (`go test ./...`)
- [x] Deploy to dev and verify condenser health improves
- [x] Check Jaeger traces show `condenser_api.*` instead of `database_api.*`