### PR TITLE
fix: Empty sentinel JSON serialization errors

### DIFF
--- a/jussi/cache/backends/max_ttl.py
+++ b/jussi/cache/backends/max_ttl.py
@@ -2,10 +2,9 @@
 from time import perf_counter
 from typing import Dict
 from typing import List
-from typing import NoReturn
 from typing import Optional
 from typing import Tuple
-from typing import TypeVar
+from typing import Union
 
 import structlog
 
@@ -17,13 +16,13 @@ MEMORY_CACHE_MAX_TTL = 180
 MEMORY_CACHE_MAX_SIZE = 2000
 
 
-CacheTTLValue = TypeVar('CacheTTL', int, float, type(None))
+CacheTTLValue = Union[int, float, None]
 CacheKey = str
 CacheKeys = List[CacheKey]
-CacheValue = TypeVar('CacheValue', int, float, str, dict)
+CacheValue = Union[int, float, str, dict]
 CachePair = Tuple[CacheKey, CacheValue]
 CachePairs = Dict[CacheKey, CacheValue]
-CacheResultValue = TypeVar('CacheValue', int, float, str, dict)
+CacheResultValue = Union[int, float, str, dict]
 CacheResult = Optional[CacheResultValue]
 CacheResults = List[CacheResult]
 
@@ -44,10 +43,6 @@ class SimplerMaxTTLMemoryCache:
         if key in self._cache:
             timestamp, result = self._cache[key]
             if timestamp - perf_counter() > 0:
-                # Filter out Empty sentinel from pre-fix cached data
-                if isinstance(result, Empty):
-                    del self._cache[key]
-                    return None
                 return result
             else:
                 del self._cache[key]
@@ -57,56 +52,48 @@ class SimplerMaxTTLMemoryCache:
         return self.gets(key)
 
     def mgets(self, keys: CacheKeys) -> CacheResults:
-        results = [self.gets(k) for k in keys]
-        # Double-check: filter any remaining Empty sentinels
-        return [None if isinstance(r, Empty) else r for r in results]
+        return [self.gets(k) for k in keys]
 
     async def mget(self, keys: CacheKeys) -> CacheResults:
-        results = [self.gets(k) for k in keys]
-        return [None if isinstance(r, Empty) else r for r in results]
+        return [self.gets(k) for k in keys]
 
-    def sets(self, key: CacheKey, value: CacheValue, expire_time: CacheTTLValue) -> NoReturn:
+    def sets(self, key: CacheKey, value: CacheValue, expire_time: CacheTTLValue) -> None:
         if expire_time is None or expire_time > self._max_ttl:
             expire_time = self._max_ttl
         self.prune()
-        # Never store Empty sentinel in the memory cache
         if isinstance(value, Empty):
             return
         self._cache[key] = (perf_counter() + expire_time), value
-        return
 
-    async def set(self, key: CacheKey, value: CacheValue, expire_time: CacheTTLValue) -> NoReturn:
+    async def set(self, key: CacheKey, value: CacheValue, expire_time: CacheTTLValue) -> None:
         return self.sets(key, value, expire_time)
 
-    def set_manys(self, data: CachePairs, expire_time: CacheTTLValue) -> NoReturn:
-        _ = [self.sets(k, v, expire_time) for k, v, in data.items()
-             if not isinstance(v, Empty)]  # Never store Empty sentinel
+    def set_manys(self, data: CachePairs, expire_time: CacheTTLValue) -> None:
+        _ = [self.sets(k, v, expire_time) for k, v in data.items()]
         return
 
-    async def set_many(self, data: CachePairs, expire_time: CacheTTLValue) -> NoReturn:
-        _ = [self.sets(k, v, expire_time) for k, v, in data.items()]
+    async def set_many(self, data: CachePairs, expire_time: CacheTTLValue) -> None:
+        _ = [self.sets(k, v, expire_time) for k, v in data.items()]
         return
 
-    def deletes(self, key: CacheKey) -> NoReturn:
+    def deletes(self, key: CacheKey) -> None:
         if key in self._cache:
             del self._cache[key]
 
-    async def delete(self, key: CacheKey) -> NoReturn:
+    async def delete(self, key: CacheKey) -> None:
         if key in self._cache:
             del self._cache[key]
 
-    def prune(self) -> NoReturn:
+    def prune(self) -> None:
         now = perf_counter()
         pruned = [k for k, v in self._items if (v[0] - now) < 0]
         for k in pruned:
             del self._cache[k]
         if len(self._items) >= self._max_size:
             del self._cache[next(iter(self._cache))]
-        return
 
-    def clears(self) -> NoReturn:
+    def clears(self) -> None:
         self._cache = {}
-        return
 
-    async def clear(self) -> NoReturn:
+    async def clear(self) -> None:
         return self.clears()

--- a/jussi/cache/backends/max_ttl.py
+++ b/jussi/cache/backends/max_ttl.py
@@ -8,7 +8,7 @@ from typing import Union
 
 import structlog
 
-from ..empty import Empty
+from ...empty import Empty
 
 logger = structlog.get_logger(__name__)
 

--- a/jussi/cache/backends/max_ttl.py
+++ b/jussi/cache/backends/max_ttl.py
@@ -9,6 +9,8 @@ from typing import TypeVar
 
 import structlog
 
+from ..empty import Empty
+
 logger = structlog.get_logger(__name__)
 
 MEMORY_CACHE_MAX_TTL = 180
@@ -42,6 +44,10 @@ class SimplerMaxTTLMemoryCache:
         if key in self._cache:
             timestamp, result = self._cache[key]
             if timestamp - perf_counter() > 0:
+                # Filter out Empty sentinel from pre-fix cached data
+                if isinstance(result, Empty):
+                    del self._cache[key]
+                    return None
                 return result
             else:
                 del self._cache[key]
@@ -51,15 +57,21 @@ class SimplerMaxTTLMemoryCache:
         return self.gets(key)
 
     def mgets(self, keys: CacheKeys) -> CacheResults:
-        return [self.gets(k) for k in keys]
+        results = [self.gets(k) for k in keys]
+        # Double-check: filter any remaining Empty sentinels
+        return [None if isinstance(r, Empty) else r for r in results]
 
     async def mget(self, keys: CacheKeys) -> CacheResults:
-        return [self.gets(k) for k in keys]
+        results = [self.gets(k) for k in keys]
+        return [None if isinstance(r, Empty) else r for r in results]
 
     def sets(self, key: CacheKey, value: CacheValue, expire_time: CacheTTLValue) -> NoReturn:
         if expire_time is None or expire_time > self._max_ttl:
             expire_time = self._max_ttl
         self.prune()
+        # Never store Empty sentinel in the memory cache
+        if isinstance(value, Empty):
+            return
         self._cache[key] = (perf_counter() + expire_time), value
         return
 
@@ -67,7 +79,8 @@ class SimplerMaxTTLMemoryCache:
         return self.sets(key, value, expire_time)
 
     def set_manys(self, data: CachePairs, expire_time: CacheTTLValue) -> NoReturn:
-        _ = [self.sets(k, v, expire_time) for k, v, in data.items()]
+        _ = [self.sets(k, v, expire_time) for k, v, in data.items()
+             if not isinstance(v, Empty)]  # Never store Empty sentinel
         return
 
     async def set_many(self, data: CachePairs, expire_time: CacheTTLValue) -> NoReturn:

--- a/jussi/cache/backends/redis.py
+++ b/jussi/cache/backends/redis.py
@@ -3,10 +3,9 @@ from zlib import compress
 from zlib import decompress
 from typing import Dict
 from typing import List
-from typing import NoReturn
 from typing import Optional
 from typing import Tuple
-from typing import TypeVar
+from typing import Union
 
 
 from ujson import dumps
@@ -14,13 +13,13 @@ from ujson import loads
 
 from ..empty import Empty
 
-CacheTTLValue = TypeVar('CacheTTL', int, float, type(None))
+CacheTTLValue = Union[int, float, None]
 CacheKey = str
 CacheKeys = List[CacheKey]
-CacheValue = TypeVar('CacheValue', int, float, str, dict)
+CacheValue = Union[int, float, str, dict]
 CachePair = Tuple[CacheKey, CacheValue]
 CachePairs = Dict[CacheKey, CacheValue]
-CacheResultValue = TypeVar('CacheValue', int, float, str, dict)
+CacheResultValue = Union[int, float, str, dict]
 CacheResult = Optional[CacheResultValue]
 CacheResults = List[CacheResult]
 
@@ -38,35 +37,25 @@ class Cache:
     def _unpack(self, value: bytes) -> CacheResult:
         if not value:
             return None
-        result = loads(decompress(value))
-        # Guard against Empty sentinel in cached data
-        if isinstance(result, Empty):
-            return None
-        return result
+        return loads(decompress(value))
 
     # pylint: enable=no-self-use
 
     async def get(self, key: CacheKey) -> CacheResult:
         res = await self.client.get(key)
         if res:
-            result = self._unpack(res)
-            # redis-py edge cases can return Empty sentinel; treat as cache miss
-            if isinstance(result, Empty):
-                return None
-            return result
+            return self._unpack(res)
         return None
 
-    async def set(self, key: str, value, expire_time: CacheTTLValue=None) -> NoReturn:
-        # Never store Empty in the cache
+    async def set(self, key: str, value, expire_time: CacheTTLValue=None) -> None:
         if isinstance(value, Empty):
             return
         value = self._pack(value)
         await self.client.set(key, value, ex=expire_time)
 
-    async def set_many(self, data: CachePairs, expire_time: CacheTTLValue=None) -> NoReturn:
+    async def set_many(self, data: CachePairs, expire_time: CacheTTLValue=None) -> None:
         async with self.client.pipeline(transaction=False) as pipeline:
             for key, value in data.items():
-                # Never store Empty in the cache
                 if isinstance(value, Empty):
                     continue
                 value = self._pack(value)
@@ -74,9 +63,7 @@ class Cache:
             return await pipeline.execute()
 
     async def mget(self, keys: CacheKeys) -> CacheResults:
-        results = [self._unpack(r) for r in await self.client.mget(keys)]
-        # Filter out any Empty sentinels from redis-py edge cases
-        return [None if isinstance(r, Empty) else r for r in results]
+        return [self._unpack(r) for r in await self.client.mget(keys)]
 
     async def clear(self):
         return await self.client.flushdb()
@@ -103,7 +90,7 @@ class MockClient:
     async def execute(self):
         pass
 
-    async def set(self, key, value, ex: CacheTTLValue=None) -> NoReturn:
+    async def set(self, key, value, ex: CacheTTLValue=None) -> None:
         self.cache.sets(key, value, ex)
 
     async def get(self, key) -> CacheResult:

--- a/jussi/cache/backends/redis.py
+++ b/jussi/cache/backends/redis.py
@@ -11,7 +11,7 @@ from typing import Union
 from ujson import dumps
 from ujson import loads
 
-from ..empty import Empty
+from ...empty import Empty
 
 CacheTTLValue = Union[int, float, None]
 CacheKey = str

--- a/jussi/cache/backends/redis.py
+++ b/jussi/cache/backends/redis.py
@@ -12,6 +12,8 @@ from typing import TypeVar
 from ujson import dumps
 from ujson import loads
 
+from ..empty import Empty
+
 CacheTTLValue = TypeVar('CacheTTL', int, float, type(None))
 CacheKey = str
 CacheKeys = List[CacheKey]
@@ -36,29 +38,45 @@ class Cache:
     def _unpack(self, value: bytes) -> CacheResult:
         if not value:
             return None
-        return loads(decompress(value))
+        result = loads(decompress(value))
+        # Guard against Empty sentinel in cached data
+        if isinstance(result, Empty):
+            return None
+        return result
 
     # pylint: enable=no-self-use
 
     async def get(self, key: CacheKey) -> CacheResult:
         res = await self.client.get(key)
         if res:
-            return self._unpack(res)
+            result = self._unpack(res)
+            # redis-py edge cases can return Empty sentinel; treat as cache miss
+            if isinstance(result, Empty):
+                return None
+            return result
         return None
 
     async def set(self, key: str, value, expire_time: CacheTTLValue=None) -> NoReturn:
+        # Never store Empty in the cache
+        if isinstance(value, Empty):
+            return
         value = self._pack(value)
         await self.client.set(key, value, ex=expire_time)
 
     async def set_many(self, data: CachePairs, expire_time: CacheTTLValue=None) -> NoReturn:
         async with self.client.pipeline(transaction=False) as pipeline:
             for key, value in data.items():
+                # Never store Empty in the cache
+                if isinstance(value, Empty):
+                    continue
                 value = self._pack(value)
                 await pipeline.set(key, value, ex=expire_time)
             return await pipeline.execute()
 
     async def mget(self, keys: CacheKeys) -> CacheResults:
-        return [self._unpack(r) for r in await self.client.mget(keys)]
+        results = [self._unpack(r) for r in await self.client.mget(keys)]
+        # Filter out any Empty sentinels from redis-py edge cases
+        return [None if isinstance(r, Empty) else r for r in results]
 
     async def clear(self):
         return await self.client.flushdb()

--- a/jussi/cache/utils.py
+++ b/jussi/cache/utils.py
@@ -5,6 +5,7 @@ from typing import Optional
 import cytoolz
 import structlog
 
+from ..empty import _empty
 from ..typedefs import BatchJrpcRequest
 from ..typedefs import CachedBatchResponse
 from ..typedefs import CachedSingleResponse
@@ -72,7 +73,8 @@ def merge_cached_response(request: SingleJrpcRequest,
                           ) -> Optional[SingleJrpcResponse]:
     if not cached_response:
         return None
-    return {'id': request.id, 'jsonrpc': '2.0', 'result': cached_response['result']}
+    # _empty id (notification request) -> None to avoid ujson serialization error
+    return {'id': request.id if request.id is not _empty else None, 'jsonrpc': '2.0', 'result': cached_response['result']}
 
 
 def merge_cached_responses(request: BatchJrpcRequest,

--- a/jussi/cache/utils.py
+++ b/jussi/cache/utils.py
@@ -10,6 +10,7 @@ from ..typedefs import CachedBatchResponse
 from ..typedefs import CachedSingleResponse
 from ..typedefs import SingleJrpcRequest
 from ..typedefs import SingleJrpcResponse
+from ..empty import Empty
 from .ttl import TTL
 
 logger = structlog.get_logger(__name__)
@@ -72,10 +73,20 @@ def merge_cached_response(request: SingleJrpcRequest,
                           ) -> Optional[SingleJrpcResponse]:
     if not cached_response:
         return None
-    return {'id': request.id, 'jsonrpc': '2.0', 'result': cached_response['result']}
+    # Guard against Empty sentinel in cached response result
+    if isinstance(cached_response, Empty):
+        return None
+    result = cached_response.get('result')
+    if isinstance(result, Empty):
+        return None
+    return {'id': request.id, 'jsonrpc': '2.0', 'result': result}
 
 
 def merge_cached_responses(request: BatchJrpcRequest,
                            cached_responses: CachedBatchResponse) -> CachedBatchResponse:
-    return [merge_cached_response(req, resp) for req, resp in zip(
-        request, cached_responses)]
+    merged = []
+    for req, resp in zip(request, cached_responses):
+        m = merge_cached_response(req, resp)
+        # merge_cached_response returns None for cache miss or Empty sentinel
+        merged.append(m)
+    return merged

--- a/jussi/cache/utils.py
+++ b/jussi/cache/utils.py
@@ -10,7 +10,6 @@ from ..typedefs import CachedBatchResponse
 from ..typedefs import CachedSingleResponse
 from ..typedefs import SingleJrpcRequest
 from ..typedefs import SingleJrpcResponse
-from ..empty import Empty
 from .ttl import TTL
 
 logger = structlog.get_logger(__name__)
@@ -73,20 +72,10 @@ def merge_cached_response(request: SingleJrpcRequest,
                           ) -> Optional[SingleJrpcResponse]:
     if not cached_response:
         return None
-    # Guard against Empty sentinel in cached response result
-    if isinstance(cached_response, Empty):
-        return None
-    result = cached_response.get('result')
-    if isinstance(result, Empty):
-        return None
-    return {'id': request.id, 'jsonrpc': '2.0', 'result': result}
+    return {'id': request.id, 'jsonrpc': '2.0', 'result': cached_response['result']}
 
 
 def merge_cached_responses(request: BatchJrpcRequest,
                            cached_responses: CachedBatchResponse) -> CachedBatchResponse:
-    merged = []
-    for req, resp in zip(request, cached_responses):
-        m = merge_cached_response(req, resp)
-        # merge_cached_response returns None for cache miss or Empty sentinel
-        merged.append(m)
-    return merged
+    return [merge_cached_response(req, resp) for req, resp in zip(
+        request, cached_responses)]

--- a/jussi/handlers.py
+++ b/jussi/handlers.py
@@ -13,6 +13,7 @@ from sanic import response
 from ujson import loads
 from websockets.exceptions import ConnectionClosed
 
+from .empty import _empty
 from .errors import InvalidUpstreamURL
 from .errors import RequestTimeoutError
 from .errors import UpstreamResponseError
@@ -157,7 +158,9 @@ async def fetch_ws(http_request: HTTPRequest,
         upstream_response = loads(upstream_response_json)
         await pool.release(conn)
         assert int(upstream_response.get('id')) == jrpc_request.upstream_id
-        upstream_response['id'] = jrpc_request.id
+        # JSON-RPC requests without "id" (notifications) store _empty as the id,
+        # which ujson cannot serialize. Convert to None (-> null in JSON).
+        upstream_response['id'] = jrpc_request.id if jrpc_request.id is not _empty else None
         jrpc_request.timings.append((perf(), 'fetch_ws.exit'))
         return upstream_response
 
@@ -202,7 +205,8 @@ async def fetch_http(http_request: HTTPRequest,
             logger.warning('upstream returned non-200 status',
                            status=resp.status,
                            request_id=jrpc_request.jussi_request_id)
-    upstream_response['id'] = jrpc_request.id
+    # Same as fetch_ws: convert _empty to None for JSON serialization
+    upstream_response['id'] = jrpc_request.id if jrpc_request.id is not _empty else None
     jrpc_request.timings.append((perf(), 'fetch_http.exit'))
     return upstream_response
 # pylint: enable=no-value-for-parameter

--- a/jussi/middlewares/caching.py
+++ b/jussi/middlewares/caching.py
@@ -10,11 +10,28 @@ from sanic import response
 from ujson import loads
 
 from ..cache.cache_group import UncacheableResponse
+from ..empty import Empty
 from ..typedefs import HTTPRequest
 from ..typedefs import HTTPResponse
 from ..utils import async_nowait_middleware
 
 logger = structlog.get_logger(__name__)
+
+
+def _contains_empty(value) -> bool:
+    """Check if value is or recursively contains the Empty sentinel.
+
+    Empty is jussi's sentinel for "not provided" in URN parsing.
+    It must never reach ujson.dumps() — it's not JSON serializable.
+    See: https://github.com/steemit/jussi-legacy/issues/XXX
+    """
+    if isinstance(value, Empty):
+        return True
+    if isinstance(value, dict):
+        return any(_contains_empty(v) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_empty(v) for v in value)
+    return False
 
 
 async def get_response(request: HTTPRequest) -> None:
@@ -44,10 +61,16 @@ async def get_response(request: HTTPRequest) -> None:
 
         if cached_response and \
                 cache_group.is_complete_response(request.jsonrpc, cached_response):
-            jussi_cache_key = cache_group.x_jussi_cache_key(request.jsonrpc)
-            request.timings.append((perf(), 'get_cached_response.exit'))
-            return response.json(cached_response,
-                                 headers={'x-jussi-cache-hit': jussi_cache_key})
+            # Guard against Empty sentinel leaking into cached responses.
+            # Empty is jussi's URN parsing sentinel and is not JSON serializable.
+            if _contains_empty(cached_response):
+                logger.warning('Empty sentinel found in cached response, skipping cache hit',
+                               request_id=request.jussi_request_id)
+            else:
+                jussi_cache_key = cache_group.x_jussi_cache_key(request.jsonrpc)
+                request.timings.append((perf(), 'get_cached_response.exit'))
+                return response.json(cached_response,
+                                     headers={'x-jussi-cache-hit': jussi_cache_key})
 
     except ConnectionRefusedError as e:
         logger.error('error connecting to redis cache', e=e)

--- a/jussi/middlewares/caching.py
+++ b/jussi/middlewares/caching.py
@@ -10,28 +10,11 @@ from sanic import response
 from ujson import loads
 
 from ..cache.cache_group import UncacheableResponse
-from ..empty import Empty
 from ..typedefs import HTTPRequest
 from ..typedefs import HTTPResponse
 from ..utils import async_nowait_middleware
 
 logger = structlog.get_logger(__name__)
-
-
-def _contains_empty(value) -> bool:
-    """Check if value is or recursively contains the Empty sentinel.
-
-    Empty is jussi's sentinel for "not provided" in URN parsing.
-    It must never reach ujson.dumps() — it's not JSON serializable.
-    See: https://github.com/steemit/jussi-legacy/issues/XXX
-    """
-    if isinstance(value, Empty):
-        return True
-    if isinstance(value, dict):
-        return any(_contains_empty(v) for v in value.values())
-    if isinstance(value, (list, tuple)):
-        return any(_contains_empty(v) for v in value)
-    return False
 
 
 async def get_response(request: HTTPRequest) -> None:
@@ -61,16 +44,10 @@ async def get_response(request: HTTPRequest) -> None:
 
         if cached_response and \
                 cache_group.is_complete_response(request.jsonrpc, cached_response):
-            # Guard against Empty sentinel leaking into cached responses.
-            # Empty is jussi's URN parsing sentinel and is not JSON serializable.
-            if _contains_empty(cached_response):
-                logger.warning('Empty sentinel found in cached response, skipping cache hit',
-                               request_id=request.jussi_request_id)
-            else:
-                jussi_cache_key = cache_group.x_jussi_cache_key(request.jsonrpc)
-                request.timings.append((perf(), 'get_cached_response.exit'))
-                return response.json(cached_response,
-                                     headers={'x-jussi-cache-hit': jussi_cache_key})
+            jussi_cache_key = cache_group.x_jussi_cache_key(request.jsonrpc)
+            request.timings.append((perf(), 'get_cached_response.exit'))
+            return response.json(cached_response,
+                                 headers={'x-jussi-cache-hit': jussi_cache_key})
 
     except ConnectionRefusedError as e:
         logger.error('error connecting to redis cache', e=e)


### PR DESCRIPTION
## Summary

- Fix `<Empty> is not JSON serializable` error when JSON-RPC requests are sent without an `id` field (notifications)
- Add `isinstance(value, Empty)` guards in cache backends to prevent Empty sentinel from reaching `ujson.dumps()`
- Fix relative import path for Empty sentinel in cache backends

## Root Cause

Two separate issues caused by the `_empty` sentinel (`jussi/empty.py`):

1. **Request path**: JSON-RPC requests without an `id` field store `_empty` as the request id. When the upstream response is returned to the client, `_empty` was placed directly into the response dict, causing `ujson.dumps()` to raise `TypeError: '<Empty> is not JSON serializable'`. This affected `fetch_ws`, `fetch_http`, and `merge_cached_response`.

2. **Cache path**: The `_empty` sentinel could be passed to cache `set()`/`set_many()` methods, where `_pack()` calls `ujson.dumps()` on the value. Added guards to skip caching when the value is an `Empty` instance.

## Changes

| File | Change |
|------|--------|
| `jussi/handlers.py` | Convert `_empty` id to `None` in `fetch_ws` and `fetch_http` response handling |
| `jussi/cache/utils.py` | Convert `_empty` id to `None` in `merge_cached_response` |
| `jussi/cache/backends/redis.py` | Add `isinstance(value, Empty)` guards in `set()` and `set_many()` |
| `jussi/cache/backends/max_ttl.py` | Add `isinstance(value, Empty)` guard in `sets()` |

## Test plan

- [x] Deploy to beta-jussi-002 environment
- [x] Send request without `id` field: `{"jsonrpc":"2.0","method":"call","params":["condenser_api","get_accounts",[["steem"]]]}`
- [x] Verify response returns `{"jsonrpc":"2.0","id":null,"result":[...]}` instead of Internal Error
- [x] Send request with `id` field and verify it still works correctly
- [ ] Monitor docker logs for absence of `<Empty> is not JSON serializable` errors