### PR TITLE
fix(cache): inject request id into middleware cache hit response

### DIFF
--- a/internal/middleware/cache.go
+++ b/internal/middleware/cache.go
@@ -39,7 +39,13 @@ func CacheLookupMiddleware(cacheGroup *cache.CacheGroup) gin.HandlerFunc {
 		ctx := context.Background()
 		cachedValue, err := cacheGroup.Get(ctx, cacheKey)
 		if err == nil && cachedValue != nil {
-			// Cache hit - return cached response
+			// Cache hit - inject current request's id into cached response
+			// to avoid returning a stale id from a previous request
+			if cachedResp, ok := cachedValue.(map[string]interface{}); ok {
+				if reqMap, ok := body.(map[string]interface{}); ok {
+					cachedResp["id"] = reqMap["id"]
+				}
+			}
 			c.JSON(200, cachedValue)
 			c.Header("x-jussi-cache-hit", cacheKey)
 			c.Abort()


### PR DESCRIPTION
## Summary

- Fix `CacheLookupMiddleware` returning cached responses with a stale `id` from the original request that populated the cache

## Problem

`CacheLookupMiddleware` performs an independent cache lookup before the processor. When it gets a cache hit, it returns the cached response directly without replacing the `id` field. This means a request with `id: 2` could receive a response with `id: 1` if the cache was populated by a previous request.

The processor's cache hit path (`processor.go:153`) correctly injects the current request id via `cachedResp["id"] = jsonrpcReq.ID`, but the middleware bypasses this.

## Fix

Extract the `id` from the current request body and overwrite the cached response's `id` before returning it, matching the behavior in `processor.go`.

## Test plan

- [ ] Send two requests with different `id` values for the same method/params
- [ ] Verify each response contains the `id` from its own request, not a stale one
- [ ] Verify cache hit header `x-jussi-cache-hit` still appears correctly