### PR TITLE
refactor: safety improvements - panic→error, mutex, type safety

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -193,7 +193,7 @@ func initCache(cfg *config.Config, logger *logging.Logger) (*cache.CacheGroup, e
 // }
 
 // SetupRouter configures the Gin router
-func (a *App) SetupRouter() *gin.Engine {
+func (a *App) SetupRouter() (*gin.Engine, error) {
 	if a.config.Logging.Level == "DEBUG" {
 		gin.SetMode(gin.DebugMode)
 	} else {
@@ -261,9 +261,11 @@ func (a *App) SetupRouter() *gin.Engine {
 	}
 
 	healthHandler := handlers.NewHealthHandler(sourceCommit, dockerTag, a.config.Telemetry.ServiceName)
-	homepageHandler := handlers.NewHomepageHandler(sourceCommit, dockerTag, a.config.Telemetry.ServiceName, a.router)
+	homepageHandler, err := handlers.NewHomepageHandler(sourceCommit, dockerTag, a.config.Telemetry.ServiceName, a.router)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create homepage handler: %w", err)
+	}
 	metricsHandler := &handlers.MetricsHandler{}
-
 	// Register routes
 	router.GET("/", homepageHandler.HandleHomepage)   // Homepage GET support
 	router.POST("/", jsonrpcHandler.HandleJSONRPC)    // JSON-RPC POST support
@@ -283,12 +285,15 @@ func (a *App) SetupRouter() *gin.Engine {
 		metricsGroup.GET("", metricsHandler.HandleMetrics)
 	}
 
-	return router
+	return router, nil
 }
 
 // Run starts the application
 func (a *App) Run() error {
-	router := a.SetupRouter()
+	router, err := a.SetupRouter()
+	if err != nil {
+		return fmt.Errorf("failed to setup router: %w", err)
+	}
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", a.config.Server.Host, a.config.Server.Port),

--- a/internal/cache/global_params.go
+++ b/internal/cache/global_params.go
@@ -26,22 +26,25 @@ type GlobalParams struct {
 }
 
 // NewGlobalParams creates a new global params cache with 3 second TTL
-// Requires router to get steemd URLs from configuration
-func NewGlobalParams(router *upstream.Router) *GlobalParams {
-	// Get steemd URLs from configuration (will panic if not configured)
-	steemdURLs := router.GetSteemdURLs()
-	
+// Requires router to get steemd URLs from configuration.
+// Returns an error if steemd is not configured.
+func NewGlobalParams(router *upstream.Router) (*GlobalParams, error) {
+	steemdURLs, err := router.GetSteemdURLs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get steemd URLs: %w", err)
+	}
+
 	return &GlobalParams{
 		ttl:        3 * time.Second,
 		router:     router,
 		steemdURLs: steemdURLs,
-	}
+	}, nil
 }
 
 // GetHeadBlockNumber returns the latest block number, fetching if cache is stale
 func (gp *GlobalParams) GetHeadBlockNumber(ctx context.Context) (int64, error) {
 	gp.mutex.RLock()
-	
+
 	// Check if cache is still valid
 	if gp.params != nil && time.Since(gp.params.LastUpdate) < gp.ttl {
 		blockNum := gp.params.HeadBlockNumber
@@ -111,4 +114,3 @@ func (gp *GlobalParams) trySteemdURL(ctx context.Context, url string) (int64, er
 	// Convert UInt32 to int64
 	return int64(dgp.HeadBlockNumber), nil
 }
-

--- a/internal/cache/irreversible.go
+++ b/internal/cache/irreversible.go
@@ -3,10 +3,12 @@ package cache
 import (
 	"fmt"
 	"strconv"
+	"sync"
 )
 
 // BlockNumberTracker tracks the last irreversible block number
 type BlockNumberTracker struct {
+	mu                       sync.RWMutex
 	lastIrreversibleBlockNum int
 }
 
@@ -19,6 +21,8 @@ func NewBlockNumberTracker() *BlockNumberTracker {
 
 // UpdateLastIrreversibleBlockNum updates the last irreversible block number
 func (b *BlockNumberTracker) UpdateLastIrreversibleBlockNum(blockNum int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if blockNum > b.lastIrreversibleBlockNum {
 		b.lastIrreversibleBlockNum = blockNum
 	}
@@ -26,6 +30,8 @@ func (b *BlockNumberTracker) UpdateLastIrreversibleBlockNum(blockNum int) {
 
 // GetLastIrreversibleBlockNum returns the last irreversible block number
 func (b *BlockNumberTracker) GetLastIrreversibleBlockNum() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return b.lastIrreversibleBlockNum
 }
 
@@ -129,4 +135,3 @@ func IrreversibleTTL(response map[string]interface{}, lastIrreversibleBlockNum i
 	// Block is not irreversible, don't cache
 	return TTLNoCache
 }
-

--- a/internal/handlers/homepage.go
+++ b/internal/handlers/homepage.go
@@ -21,14 +21,19 @@ type HomepageHandler struct {
 	GlobalParams *cache.GlobalParams
 }
 
-// NewHomepageHandler creates a new homepage handler
-func NewHomepageHandler(sourceCommit, dockerTag, serviceName string, router *upstream.Router) *HomepageHandler {
+// NewHomepageHandler creates a new homepage handler.
+// Returns an error if required upstream configuration is missing.
+func NewHomepageHandler(sourceCommit, dockerTag, serviceName string, router *upstream.Router) (*HomepageHandler, error) {
+	gp, err := cache.NewGlobalParams(router)
+	if err != nil {
+		return nil, err
+	}
 	return &HomepageHandler{
 		SourceCommit: sourceCommit,
 		DockerTag:    dockerTag,
 		ServiceName:  serviceName,
-		GlobalParams: cache.NewGlobalParams(router),
-	}
+		GlobalParams: gp,
+	}, nil
 }
 
 // HandleHomepage handles GET / requests

--- a/internal/request/jsonrpc.go
+++ b/internal/request/jsonrpc.go
@@ -71,10 +71,10 @@ func FromHTTPRequest(httpReq *HTTPRequest, batchIndex int, rawRequest map[string
 		Timeout: 5,
 	}
 
-	id, _ := rawRequest["id"]
+	id := rawRequest["id"]
 	jsonrpc, _ := rawRequest["jsonrpc"].(string)
 	method, _ := rawRequest["method"].(string)
-	params, _ := rawRequest["params"]
+	params := rawRequest["params"]
 
 	return &JSONRPCRequest{
 		ID:             id,

--- a/internal/upstream/http.go
+++ b/internal/upstream/http.go
@@ -22,7 +22,9 @@ type HTTPClient struct {
 func NewHTTPClient() *HTTPClient {
 	return &HTTPClient{
 		client: &http.Client{
-			Timeout: 30 * time.Second,
+			// Do not set a global timeout here; each request uses
+			// context.WithTimeout in callHTTPUpstream to avoid nested
+			// timeout conflicts between transport and context.
 			Transport: &http.Transport{
 				MaxIdleConns:        100,
 				MaxIdleConnsPerHost: 10,

--- a/internal/upstream/router.go
+++ b/internal/upstream/router.go
@@ -1,6 +1,8 @@
 package upstream
 
 import (
+	"fmt"
+
 	"github.com/steemit/jussi/internal/config"
 )
 
@@ -65,19 +67,19 @@ func (r *Router) ShouldTranslateToAppbase(namespace string) bool {
 	return r.translateToAppbase[namespace]
 }
 
-// GetSteemdURLs returns all configured steemd URLs
-// Panics if steemd is not configured (required for global params)
-func (r *Router) GetSteemdURLs() []string {
+// GetSteemdURLs returns all configured steemd URLs.
+// Returns an error if steemd is not configured.
+func (r *Router) GetSteemdURLs() ([]string, error) {
 	var urls []string
 	urlSet := make(map[string]bool)
 
 	if r.upstreamConfig == nil {
-		panic("upstream configuration is required but not found")
+		return nil, fmt.Errorf("upstream configuration is required but not found")
 	}
 
 	// Collect from upstreams array
 	if len(r.upstreamConfig.Upstreams) == 0 {
-		panic("upstreams configuration is required but not found")
+		return nil, fmt.Errorf("upstreams configuration is required but not found")
 	}
 
 	for _, upstream := range r.upstreamConfig.Upstreams {
@@ -96,19 +98,20 @@ func (r *Router) GetSteemdURLs() []string {
 	}
 
 	if len(urls) == 0 {
-		panic("steemd upstream is required but not found in configuration")
+		return nil, fmt.Errorf("steemd upstream is required but not found in configuration")
 	}
 
-	return urls
+	return urls, nil
 }
 
-// GetAllURLs returns all configured URLs
-func (r *Router) GetAllURLs() []string {
+// GetAllURLs returns all configured URLs.
+// Returns an error if no URLs are configured.
+func (r *Router) GetAllURLs() ([]string, error) {
 	urls := r.getAllURLsFromConfig()
 	if len(urls) == 0 {
-		panic("upstreams configuration is required but contains no URLs")
+		return nil, fmt.Errorf("upstreams configuration is required but contains no URLs")
 	}
-	return urls
+	return urls, nil
 }
 
 // GetNamespaces returns all configured namespaces
@@ -312,7 +315,7 @@ func (r *Router) getTimeoutFromConfig(urn string) int {
 }
 
 // getAllURLsFromConfig collects all URLs from configuration
-// Returns empty slice if no configuration (caller should panic)
+// Returns empty slice if no configuration (caller should handle)
 func (r *Router) getAllURLsFromConfig() []string {
 	var urls []string
 	urlSet := make(map[string]bool)

--- a/internal/upstream/router_test.go
+++ b/internal/upstream/router_test.go
@@ -151,7 +151,10 @@ func TestURLsConfig(t *testing.T) {
 		t.Fatalf("failed to create router: %v", err)
 	}
 
-	urls := router.GetAllURLs()
+	urls, err := router.GetAllURLs()
+	if err != nil {
+		t.Fatalf("GetAllURLs failed: %v", err)
+	}
 	expectedURLs := map[string]bool{
 		"http://test.com":  true,
 		"http://test2.com": true,
@@ -363,8 +366,14 @@ func TestHash(t *testing.T) {
 	}
 
 	// Compare URLs (convert to sets for comparison since order may differ)
-	urls1 := router1.GetAllURLs()
-	urls2 := router2.GetAllURLs()
+	urls1, err := router1.GetAllURLs()
+	if err != nil {
+		t.Fatalf("router1.GetAllURLs failed: %v", err)
+	}
+	urls2, err := router2.GetAllURLs()
+	if err != nil {
+		t.Fatalf("router2.GetAllURLs failed: %v", err)
+	}
 	urls1Set := make(map[string]bool)
 	urls2Set := make(map[string]bool)
 	for _, url := range urls1 {
@@ -468,8 +477,14 @@ func TestHashIneq(t *testing.T) {
 	}
 
 	// Compare URLs
-	urls1 := router1.GetAllURLs()
-	urls2 := router2.GetAllURLs()
+	urls1, err := router1.GetAllURLs()
+	if err != nil {
+		t.Fatalf("router1.GetAllURLs failed: %v", err)
+	}
+	urls2, err := router2.GetAllURLs()
+	if err != nil {
+		t.Fatalf("router2.GetAllURLs failed: %v", err)
+	}
 	if reflect.DeepEqual(urls1, urls2) {
 		t.Error("routers with different config should have different URLs")
 	}
@@ -508,7 +523,10 @@ func TestRouterWithTestConfig(t *testing.T) {
 	}
 
 	// Test that we can get steemd URLs
-	steemdURLs := router.GetSteemdURLs()
+	steemdURLs, err := router.GetSteemdURLs()
+	if err != nil {
+		t.Fatalf("GetSteemdURLs failed: %v", err)
+	}
 	if len(steemdURLs) == 0 {
 		t.Error("expected at least one steemd URL")
 	}

--- a/internal/upstream/validation.go
+++ b/internal/upstream/validation.go
@@ -28,7 +28,10 @@ func ValidateUpstreamURLs(cfg *config.Config) error {
 	}
 
 	// Get all unique URLs from router
-	urls := router.GetAllURLs()
+	urls, err := router.GetAllURLs()
+	if err != nil {
+		return fmt.Errorf("failed to get upstream URLs: %w", err)
+	}
 
 	// Test each URL
 	for _, urlStr := range urls {

--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -50,7 +50,11 @@ func ValidateJSONRPCRequest(request interface{}) error {
 			return fmt.Errorf("batch request cannot be empty")
 		}
 		for i, r := range req {
-			if err := validateSingleRequest(r.(map[string]interface{})); err != nil {
+			reqMap, ok := r.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("batch request[%d]: request must be an object", i)
+			}
+			if err := validateSingleRequest(reqMap); err != nil {
 				return fmt.Errorf("batch request[%d]: %w", i, err)
 			}
 		}


### PR DESCRIPTION
## Summary

Extracted from PR #250 to keep the batch response id fix focused.

### Changes

**Panic → Error returns (Go best practices)**
- `Router.GetSteemdURLs()` and `Router.GetAllURLs()` return `error` instead of panicking
- `cache.NewGlobalParams()` returns `error` instead of panicking
- `handlers.NewHomepageHandler()` returns `error` to propagate upstream
- `App.SetupRouter()` returns `(*gin.Engine, error)` to propagate handler errors
- `App.Run()` handles the new error return from `SetupRouter()`

**Concurrency safety**
- `BlockNumberTracker` now uses `sync.RWMutex` to protect concurrent read/write of `lastIrreversibleBlockNum` (accessed by batch processor goroutines)

**Type safety**
- `validators.ValidateJSONRPCRequest` safely checks batch element type before assertion (prevents panic on non-object elements)

**Timeout cleanup**
- Remove redundant `http.Client.Timeout` — per-request `context.WithTimeout` is used instead (default 5s fallback)

**Style**
- Minor cleanup in `request/jsonrpc.go`

### Testing
- All tests pass (`go test ./... -race -count=1`)
- No new test failures introduced