### PR TITLE
refactor: remove hostname and service_name from health check response

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -260,7 +260,7 @@ func (a *App) SetupRouter() (*gin.Engine, error) {
 		dockerTag = "unknown"
 	}
 
-	healthHandler := handlers.NewHealthHandler(sourceCommit, dockerTag, a.config.Telemetry.ServiceName)
+	healthHandler := handlers.NewHealthHandler(sourceCommit, dockerTag)
 	homepageHandler, err := handlers.NewHomepageHandler(sourceCommit, dockerTag, a.config.Telemetry.ServiceName, a.router)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create homepage handler: %w", err)

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -12,31 +11,25 @@ import (
 type HealthHandler struct {
 	SourceCommit string
 	DockerTag    string
-	ServiceName  string
 	// TODO: Add last irreversible block number tracking
 }
 
 // NewHealthHandler creates a new health handler
-func NewHealthHandler(sourceCommit, dockerTag, serviceName string) *HealthHandler {
+func NewHealthHandler(sourceCommit, dockerTag string) *HealthHandler {
 	return &HealthHandler{
 		SourceCommit: sourceCommit,
 		DockerTag:    dockerTag,
-		ServiceName:  serviceName,
 	}
 }
 
 // HandleHealth handles GET /health requests
 // Returns health information similar to the legacy project
 func (h *HealthHandler) HandleHealth(c *gin.Context) {
-	hostname, _ := os.Hostname()
-	
 	response := gin.H{
 		"status":        "OK",
 		"datetime":      time.Now().UTC().Format(time.RFC3339),
 		"source_commit": h.SourceCommit,
 		"docker_tag":    h.DockerTag,
-		"service_name":  h.ServiceName,
-		"hostname":      hostname,
 		// TODO: Add jussi_num (last irreversible block number) when block tracking is implemented
 		// "jussi_num":     h.LastIrreversibleBlockNum,
 	}

--- a/tests/integration/routes_test.go
+++ b/tests/integration/routes_test.go
@@ -23,7 +23,7 @@ func setupRoutesTestServer() *httptest.Server {
 	r.Use(middleware.RequestIDMiddleware())
 
 	// Create health handler
-	healthHandler := handlers.NewHealthHandler("test-commit", "test-tag", "test-service")
+	healthHandler := handlers.NewHealthHandler("test-commit", "test-tag")
 
 	// Setup routes
 	r.GET("/health", healthHandler.HandleHealth)


### PR DESCRIPTION
## Summary
- Remove `hostname` (`os.Hostname()`) and `service_name` from the `/health` endpoint response
- Simplify `NewHealthHandler` signature: drop `serviceName` parameter
- Remove `ServiceName` struct field and `os` import

## Health Response (after)
```json
{"status": "OK", "datetime": "...", "source_commit": "...", "docker_tag": "..."}
```

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./...` all pass (including integration tests)
