### PR TITLE
fix: emulate get_state for unsupported sub-paths (transfers/author-rewards/curation-rewards/delegations)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,6 +224,10 @@ func bindEnvOverrides() {
 
 		// Limits
 		{"JUSSI_LIMITS_ACCOUNT_HISTORY_LIMIT", "limits.account_history_limit"},
+
+		// Cache key prefix for workaround sub-request caching
+		// Read at init() time in get_state_workaround.go, not via viper.
+		// Documented here for reference.
 	}
 
 	for _, m := range envMappings {

--- a/internal/handlers/get_state_workaround.go
+++ b/internal/handlers/get_state_workaround.go
@@ -1,0 +1,384 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/steemit/jussi/internal/request"
+	"github.com/steemit/jussi/internal/upstream"
+	"github.com/steemit/jussi/internal/urn"
+)
+
+// ============================================================================
+// TEMPORARY WORKAROUND: get_state sub-path emulation
+// ============================================================================
+//
+// Background:
+//   steemd's condenser_api.get_state only supports a limited set of sub-paths:
+//     - /@user/transfers
+//     - /@user/recent-replies
+//     - /@user/posts, /@user/comments
+//     - /@user/blog, /@user/feed
+//
+//   The following sub-paths were NEVER implemented in steemd's get_state:
+//     - /@user/author-rewards
+//     - /@user/curation-rewards
+//     - /@user/delegations
+//
+//   Calling get_state with these paths causes steemd to return
+//   -32602 "Invalid parameters". The old wallet (condenser-based) and
+//   some third-party clients still request these paths, causing the
+//   frontend SSR to hang until timeout (~344 seconds) and return 504.
+//
+//   The new wallet (Next.js) has completely migrated away from get_state
+//   and uses direct API calls:
+//     - /api/query/history             -> get_account_history
+//     - /api/query/vesting-delegations -> get_vesting_delegations
+//
+// Solution:
+//   Intercept get_state requests with unsupported sub-paths at the jussi
+//   layer and emulate the expected get_state response by:
+//     1. Calling get_state("/@username") for base account data
+//     2. Calling get_account_history for author/curation rewards
+//     3. Calling get_vesting_delegations for delegation data
+//     4. Assembling a response in the same format get_state returns
+//
+// Removal:
+//   DELETE THIS FILE once all clients have migrated to the new wallet or
+//   to direct API calls. Track usage via the "workaround_success" metric
+//   in Prometheus and remove when request count drops to zero.
+//   Also remove the corresponding intercept block in processor.go
+//   (search for "TEMPORARY WORKAROUND" comment).
+//
+// Added: 2026-05-25
+// Related: beta-wallet 504 investigation, steemd get_state limitations
+// ============================================================================
+
+// subRequestTimeout is the per-request timeout for workaround internal calls.
+const subRequestTimeout = 15 * time.Second
+
+// maxHistoryEntries caps the number of filtered entries we inject into
+// transfer_history to keep response size reasonable.
+const maxHistoryEntries = 200
+
+// getStateSubPathRegex matches unsupported get_state sub-paths.
+// NOTE: "transfers" is intentionally excluded — steemd supports it natively.
+var getStateSubPathRegex = regexp.MustCompile(
+	`^/?@([^/\s]+)/(author-rewards|curation-rewards|delegations)$`,
+)
+
+// isGetStateUnsupportedSubPath checks if a request is condenser_api.get_state
+// with a sub-path that steemd does NOT handle natively.
+// Returns (username, subPath, true) when interception is needed.
+func isGetStateUnsupportedSubPath(jsonrpcReq *request.JSONRPCRequest) (string, string, bool) {
+	if jsonrpcReq.URN.API != "condenser_api" || jsonrpcReq.URN.Method != "get_state" {
+		return "", "", false
+	}
+
+	params, ok := jsonrpcReq.Params.([]interface{})
+	if !ok || len(params) != 1 {
+		return "", "", false
+	}
+	path, ok := params[0].(string)
+	if !ok {
+		return "", "", false
+	}
+
+	matches := getStateSubPathRegex.FindStringSubmatch(path)
+	if matches == nil {
+		return "", "", false
+	}
+
+	return matches[1], matches[2], true // username, subPath
+}
+
+// emulateGetStateSubPath constructs a synthetic get_state response for
+// unsupported sub-paths by calling the steemd upstream directly.
+func (p *RequestProcessor) emulateGetStateSubPath(
+	ctx context.Context,
+	jsonrpcReq *request.JSONRPCRequest,
+	username string,
+	subPath string,
+) (map[string]interface{}, error) {
+	// Resolve the steemd upstream URL via the router
+	upstreamURL, err := p.getSteemdUpstreamURL()
+	if err != nil {
+		return nil, fmt.Errorf("get_state workaround: %w", err)
+	}
+
+	// Step 1: Fetch base account state via get_state("/@username")
+	baseResp, err := p.callSteemd(ctx, upstreamURL, "condenser_api.get_state",
+		[]interface{}{fmt.Sprintf("/@%s", username)}, jsonrpcReq)
+	if err != nil {
+		return nil, fmt.Errorf("get_state workaround: base get_state failed: %w", err)
+	}
+
+	// If base request returned an error, pass it through
+	if _, hasErr := baseResp["error"]; hasErr {
+		baseResp["id"] = jsonrpcReq.ID
+		return baseResp, nil
+	}
+
+	result, ok := baseResp["result"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("get_state workaround: unexpected base response format")
+	}
+
+	// Step 2: Fetch sub-path-specific data
+	switch subPath {
+	case "author-rewards":
+		p.fillRewardHistory(ctx, upstreamURL, jsonrpcReq, result, username, isAuthorRewardOp)
+
+	case "curation-rewards":
+		p.fillRewardHistory(ctx, upstreamURL, jsonrpcReq, result, username, isCurationRewardOp)
+
+	case "delegations":
+		p.fillDelegations(ctx, upstreamURL, jsonrpcReq, result, username)
+	}
+
+	result["current_route"] = fmt.Sprintf("/@%s/%s", username, subPath)
+	baseResp["id"] = jsonrpcReq.ID
+	return baseResp, nil
+}
+
+// fillRewardHistory fetches get_account_history and filters by op type,
+// injecting matching operations into the account's transfer_history field.
+func (p *RequestProcessor) fillRewardHistory(
+	ctx context.Context,
+	upstreamURL string,
+	jsonrpcReq *request.JSONRPCRequest,
+	result map[string]interface{},
+	username string,
+	opFilter func(string) bool,
+) {
+	// Fetch last 1000 history entries (steemd max limit)
+	historyResp, err := p.callSteemd(ctx, upstreamURL, "condenser_api.get_account_history",
+		[]interface{}{username, -1, 1000}, jsonrpcReq)
+	if err != nil {
+		slog.Warn("get_state workaround: get_account_history failed",
+			"username", username, "error", err)
+		return // non-fatal: return base state without history
+	}
+
+	historyResult, ok := historyResp["result"].([]interface{})
+	if !ok {
+		return
+	}
+
+	// Get account entry from get_state result
+	accounts, ok := result["accounts"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	account, ok := accounts[username].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	// Build filtered transfer_history in the same format steemd uses:
+	// map of "index_string" -> {"op": ["op_type", {op_data}]}
+	transferHistory := make(map[string]interface{})
+	count := 0
+	for _, item := range historyResult {
+		if count >= maxHistoryEntries {
+			break
+		}
+		entry, ok := item.([]interface{})
+		if !ok || len(entry) < 2 {
+			continue
+		}
+		index, ok := entry[0].(float64)
+		if !ok {
+			continue
+		}
+		opObj, ok := entry[1].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		op, ok := opObj["op"].([]interface{})
+		if !ok || len(op) < 1 {
+			continue
+		}
+		opType, ok := op[0].(string)
+		if !ok {
+			continue
+		}
+
+		if opFilter(opType) {
+			transferHistory[fmt.Sprintf("%d", int(index))] = opObj
+			count++
+		}
+	}
+
+	account["transfer_history"] = transferHistory
+}
+
+// fillDelegations fetches outgoing and incoming vesting delegations
+// and injects them into the account's transfer_history field.
+func (p *RequestProcessor) fillDelegations(
+	ctx context.Context,
+	upstreamURL string,
+	jsonrpcReq *request.JSONRPCRequest,
+	result map[string]interface{},
+	username string,
+) {
+	accounts, ok := result["accounts"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	account, ok := accounts[username].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	var (
+		wg             sync.WaitGroup
+		outDelegsResp  map[string]interface{}
+		outErr         error
+		inDelegsResp   map[string]interface{}
+		inErr          error
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		// Outgoing delegations via condenser_api
+		outDelegsResp, outErr = p.callSteemd(ctx, upstreamURL,
+			"condenser_api.get_vesting_delegations",
+			[]interface{}{username, "", 100}, jsonrpcReq)
+	}()
+	go func() {
+		defer wg.Done()
+		// Incoming delegations via database_api.list_vesting_delegations
+		// Use start object to position at the target delegatee for efficient
+		// filtering. The API returns delegations ordered by delegatee, so we
+		// seek to {delegatee: username, delegator: ""} and collect up to 100.
+		inDelegsResp, inErr = p.callSteemd(ctx, upstreamURL,
+			"database_api.list_vesting_delegations",
+			[]interface{}{map[string]interface{}{
+				"start": map[string]interface{}{
+					"delegatee": username,
+					"delegator": "",
+				},
+				"limit": 100,
+				"order": "by_delegatee",
+			}}, jsonrpcReq)
+	}()
+	wg.Wait()
+
+	if outErr != nil {
+		slog.Warn("get_state workaround: outgoing delegations failed",
+			"username", username, "error", outErr)
+	}
+	if inErr != nil {
+		slog.Warn("get_state workaround: incoming delegations failed",
+			"username", username, "error", inErr)
+	}
+
+	// Build synthetic transfer_history with delegation entries
+	transferHistory := make(map[string]interface{})
+	idx := 0
+
+	// Outgoing delegations: response is array of delegation objects
+	if outDelegsResp != nil {
+		if outResult, ok := outDelegsResp["result"].([]interface{}); ok {
+			for _, del := range outResult {
+				if idx >= maxHistoryEntries {
+					break
+				}
+				if delMap, ok := del.(map[string]interface{}); ok {
+					transferHistory[fmt.Sprintf("%d", idx)] = map[string]interface{}{
+						"op": []interface{}{"delegate_vesting_shares", delMap},
+					}
+					idx++
+				}
+			}
+		}
+	}
+
+	// Incoming delegations: response has {delegations: [...]}
+	if inDelegsResp != nil {
+		if inResult, ok := inDelegsResp["result"].(map[string]interface{}); ok {
+			if delegations, ok := inResult["delegations"].([]interface{}); ok {
+				for _, del := range delegations {
+					if idx >= maxHistoryEntries {
+						break
+					}
+					if delMap, ok := del.(map[string]interface{}); ok {
+						transferHistory[fmt.Sprintf("%d", idx)] = map[string]interface{}{
+							"op": []interface{}{"delegate_vesting_shares", delMap},
+						}
+						idx++
+					}
+				}
+			}
+		}
+	}
+
+	account["transfer_history"] = transferHistory
+}
+
+// --- Helper functions ---
+
+func isAuthorRewardOp(opType string) bool {
+	return opType == "author_reward" || opType == "comment_benefactor_reward"
+}
+
+func isCurationRewardOp(opType string) bool {
+	return opType == "curation_reward"
+}
+
+// getSteemdUpstreamURL resolves the upstream URL for condenser_api requests.
+// Constructs a synthetic URN without Params so URN.String() produces
+// "appbase.condenser_api.get_state" which matches the router config.
+func (p *RequestProcessor) getSteemdUpstreamURL() (string, error) {
+	synthURN := &urn.URN{
+		Namespace: "appbase",
+		API:       "condenser_api",
+		Method:    "get_state",
+		// Params intentionally nil: URN.String() must produce
+		// "appbase.condenser_api.get_state" (without params suffix)
+		// to match the router's longest-prefix lookup.
+	}
+	upstreamConfig, found := p.router.GetUpstream(synthURN.String())
+	if !found {
+		return "", fmt.Errorf("no upstream configured for %s", synthURN.String())
+	}
+	return upstreamConfig.URL, nil
+}
+
+// callSteemd sends a single JSON-RPC request to the steemd upstream
+// with an independent timeout to avoid cascading context cancellation.
+func (p *RequestProcessor) callSteemd(
+	ctx context.Context,
+	upstreamURL string,
+	method string,
+	params []interface{},
+	originalReq *request.JSONRPCRequest,
+) (map[string]interface{}, error) {
+	// Create a per-request timeout context to prevent one slow call
+	// from consuming the entire parent context budget.
+	subCtx, cancel := context.WithTimeout(ctx, subRequestTimeout)
+	defer cancel()
+
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  params,
+		"id":      originalReq.UpstreamID(),
+	}
+	headers := originalReq.UpstreamHeaders()
+
+	retryCfg := &upstream.RetryConfig{
+		MaxRetries:        1,
+		InitialBackoff:    100 * time.Millisecond,
+		MaxBackoff:        1 * time.Second,
+		BackoffMultiplier: 2.0,
+	}
+
+	return p.httpClient.RequestWithRetry(subCtx, upstreamURL, payload, headers, retryCfg)
+}

--- a/internal/handlers/get_state_workaround.go
+++ b/internal/handlers/get_state_workaround.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"regexp"
 	"sync"
 	"time"
@@ -14,15 +16,13 @@ import (
 )
 
 // ============================================================================
-// TEMPORARY WORKAROUND: get_state sub-path emulation
+// TEMPORARY WORKAROUND: get_state sub-path emulation (with Redis cache)
 // ============================================================================
 //
 // Background:
 //   steemd's condenser_api.get_state only supports a limited set of sub-paths:
-//     - /@user/transfers
-//     - /@user/recent-replies
-//     - /@user/posts, /@user/comments
-//     - /@user/blog, /@user/feed
+//     - /@user/transfers, /@user/recent-replies
+//     - /@user/posts, /@user/comments, /@user/blog, /@user/feed
 //
 //   The following sub-paths were NEVER implemented in steemd's get_state:
 //     - /@user/author-rewards
@@ -30,14 +30,11 @@ import (
 //     - /@user/delegations
 //
 //   Calling get_state with these paths causes steemd to return
-//   -32602 "Invalid parameters". The old wallet (condenser-based) and
-//   some third-party clients still request these paths, causing the
-//   frontend SSR to hang until timeout (~344 seconds) and return 504.
+//   -32602 "Invalid parameters". Some third-party clients or direct API
+//   calls still request these paths, causing 504 timeouts.
 //
 //   The new wallet (Next.js) has completely migrated away from get_state
-//   and uses direct API calls:
-//     - /api/query/history             -> get_account_history
-//     - /api/query/vesting-delegations -> get_vesting_delegations
+//   and uses direct API calls (get_account_history, get_vesting_delegations).
 //
 // Solution:
 //   Intercept get_state requests with unsupported sub-paths at the jussi
@@ -46,6 +43,21 @@ import (
 //     2. Calling get_account_history for author/curation rewards
 //     3. Calling get_vesting_delegations for delegation data
 //     4. Assembling a response in the same format get_state returns
+//
+//   All sub-requests are cached in Redis with fine-grained keys to maximize
+//   reuse across different sub-paths for the same user.
+//
+// Cache key design (for maximum reuse):
+//
+//   {prefix}gs:base:{username}         — get_state("/@user") base account data
+//   {prefix}gs:hist:{username}         — get_account_history full result
+//   {prefix}gs:deleg_out:{username}    — get_vesting_delegations (outgoing)
+//   {prefix}gs:deleg_in:{username}     — list_vesting_delegations (incoming)
+//
+//   Where {prefix} is read from JUSSI_CACHE_KEY_PREFIX env var (default: "jussi.")
+//
+//   author-rewards and curation-rewards both reuse gs:hist:{username},
+//   only differing in the client-side filter applied to the cached data.
 //
 // Removal:
 //   DELETE THIS FILE once all clients have migrated to the new wallet or
@@ -58,12 +70,44 @@ import (
 // Related: beta-wallet 504 investigation, steemd get_state limitations
 // ============================================================================
 
-// subRequestTimeout is the per-request timeout for workaround internal calls.
-const subRequestTimeout = 15 * time.Second
+// Configuration constants
+const (
+	subRequestTimeout = 15 * time.Second
+	maxHistoryEntries = 200
+	workaroundCacheTTL = 10 * time.Second
+)
 
-// maxHistoryEntries caps the number of filtered entries we inject into
-// transfer_history to keep response size reasonable.
-const maxHistoryEntries = 200
+// cacheKeyPrefix is the global prefix for workaround cache keys.
+// Configurable via JUSSI_CACHE_KEY_PREFIX environment variable.
+var cacheKeyPrefix string
+
+func init() {
+	cacheKeyPrefix = os.Getenv("JUSSI_CACHE_KEY_PREFIX")
+	if cacheKeyPrefix == "" {
+		cacheKeyPrefix = "jussi."
+	}
+}
+
+// Fine-grained cache key generators.
+// Each targets a specific sub-request to maximize cross-subpath reuse:
+//   - gs:base is reused by all three sub-paths
+//   - gs:hist is reused by both author-rewards and curation-rewards
+//   - gs:deleg_out and gs:deleg_in are only used by delegations
+func cacheKeyBase(username string) string {
+	return cacheKeyPrefix + "gs:base:" + username
+}
+
+func cacheKeyHistory(username string) string {
+	return cacheKeyPrefix + "gs:hist:" + username
+}
+
+func cacheKeyDelegOut(username string) string {
+	return cacheKeyPrefix + "gs:deleg_out:" + username
+}
+
+func cacheKeyDelegIn(username string) string {
+	return cacheKeyPrefix + "gs:deleg_in:" + username
+}
 
 // getStateSubPathRegex matches unsupported get_state sub-paths.
 // NOTE: "transfers" is intentionally excluded — steemd supports it natively.
@@ -93,11 +137,12 @@ func isGetStateUnsupportedSubPath(jsonrpcReq *request.JSONRPCRequest) (string, s
 		return "", "", false
 	}
 
-	return matches[1], matches[2], true // username, subPath
+	return matches[1], matches[2], true
 }
 
 // emulateGetStateSubPath constructs a synthetic get_state response for
-// unsupported sub-paths by calling the steemd upstream directly.
+// unsupported sub-paths by calling the steemd upstream directly,
+// with Redis caching at the sub-request level.
 func (p *RequestProcessor) emulateGetStateSubPath(
 	ctx context.Context,
 	jsonrpcReq *request.JSONRPCRequest,
@@ -110,9 +155,12 @@ func (p *RequestProcessor) emulateGetStateSubPath(
 		return nil, fmt.Errorf("get_state workaround: %w", err)
 	}
 
-	// Step 1: Fetch base account state via get_state("/@username")
-	baseResp, err := p.callSteemd(ctx, upstreamURL, "condenser_api.get_state",
-		[]interface{}{fmt.Sprintf("/@%s", username)}, jsonrpcReq)
+	// Step 1: Fetch base account state — cached by username
+	baseResp, err := p.fetchCachedOrCall(ctx, upstreamURL, cacheKeyBase(username),
+		"condenser_api.get_state",
+		[]interface{}{fmt.Sprintf("/@%s", username)},
+		jsonrpcReq,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("get_state workaround: base get_state failed: %w", err)
 	}
@@ -128,7 +176,7 @@ func (p *RequestProcessor) emulateGetStateSubPath(
 		return nil, fmt.Errorf("get_state workaround: unexpected base response format")
 	}
 
-	// Step 2: Fetch sub-path-specific data
+	// Step 2: Fetch sub-path-specific data (with caching)
 	switch subPath {
 	case "author-rewards":
 		p.fillRewardHistory(ctx, upstreamURL, jsonrpcReq, result, username, isAuthorRewardOp)
@@ -145,8 +193,56 @@ func (p *RequestProcessor) emulateGetStateSubPath(
 	return baseResp, nil
 }
 
+// fetchCachedOrCall checks Redis cache first, falls back to upstream call,
+// then caches the result. This is the core caching primitive for the workaround.
+// Returns the full JSON-RPC response (including "result" key) from either
+// cache or fresh upstream call.
+func (p *RequestProcessor) fetchCachedOrCall(
+	ctx context.Context,
+	upstreamURL string,
+	cacheKey string,
+	method string,
+	params []interface{},
+	jsonrpcReq *request.JSONRPCRequest,
+) (map[string]interface{}, error) {
+	// Try cache first
+	if p.cacheGroup != nil {
+		cached, err := p.cacheGroup.Get(ctx, cacheKey)
+		if err == nil && cached != nil {
+			if cachedMap, ok := cached.(map[string]interface{}); ok {
+				slog.Debug("get_state workaround: cache hit",
+					"key", cacheKey, "method", method)
+				return cachedMap, nil
+			}
+		}
+	}
+
+	// Cache miss — call upstream
+	resp, err := p.callSteemd(ctx, upstreamURL, method, params, jsonrpcReq)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store in cache (only cache successful responses)
+	if p.cacheGroup != nil && resp["error"] == nil {
+		// Deep copy before caching to avoid shared reference issues
+		cached := deepCopyMap(resp)
+		go func() {
+			bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := p.cacheGroup.Set(bgCtx, cacheKey, cached, workaroundCacheTTL); err != nil {
+				slog.Warn("get_state workaround: cache set failed",
+					"key", cacheKey, "error", err)
+			}
+		}()
+	}
+
+	return resp, nil
+}
+
 // fillRewardHistory fetches get_account_history and filters by op type,
 // injecting matching operations into the account's transfer_history field.
+// The full history is cached (shared between author-rewards and curation-rewards).
 func (p *RequestProcessor) fillRewardHistory(
 	ctx context.Context,
 	upstreamURL string,
@@ -155,9 +251,12 @@ func (p *RequestProcessor) fillRewardHistory(
 	username string,
 	opFilter func(string) bool,
 ) {
-	// Fetch last 1000 history entries (steemd max limit)
-	historyResp, err := p.callSteemd(ctx, upstreamURL, "condenser_api.get_account_history",
-		[]interface{}{username, -1, 1000}, jsonrpcReq)
+	// Fetch full history — cached by username (reused across reward types)
+	historyResp, err := p.fetchCachedOrCall(ctx, upstreamURL, cacheKeyHistory(username),
+		"condenser_api.get_account_history",
+		[]interface{}{username, -1, 1000},
+		jsonrpcReq,
+	)
 	if err != nil {
 		slog.Warn("get_state workaround: get_account_history failed",
 			"username", username, "error", err)
@@ -219,6 +318,7 @@ func (p *RequestProcessor) fillRewardHistory(
 
 // fillDelegations fetches outgoing and incoming vesting delegations
 // and injects them into the account's transfer_history field.
+// Both sub-requests are cached independently.
 func (p *RequestProcessor) fillDelegations(
 	ctx context.Context,
 	upstreamURL string,
@@ -246,18 +346,20 @@ func (p *RequestProcessor) fillDelegations(
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		// Outgoing delegations via condenser_api
-		outDelegsResp, outErr = p.callSteemd(ctx, upstreamURL,
+		// Outgoing delegations — cached independently
+		outDelegsResp, outErr = p.fetchCachedOrCall(ctx, upstreamURL,
+			cacheKeyDelegOut(username),
 			"condenser_api.get_vesting_delegations",
 			[]interface{}{username, "", 100}, jsonrpcReq)
 	}()
 	go func() {
 		defer wg.Done()
-		// Incoming delegations via database_api.list_vesting_delegations
+		// Incoming delegations — cached independently
 		// Use start object to position at the target delegatee for efficient
 		// filtering. The API returns delegations ordered by delegatee, so we
 		// seek to {delegatee: username, delegator: ""} and collect up to 100.
-		inDelegsResp, inErr = p.callSteemd(ctx, upstreamURL,
+		inDelegsResp, inErr = p.fetchCachedOrCall(ctx, upstreamURL,
+			cacheKeyDelegIn(username),
 			"database_api.list_vesting_delegations",
 			[]interface{}{map[string]interface{}{
 				"start": map[string]interface{}{
@@ -360,8 +462,7 @@ func (p *RequestProcessor) callSteemd(
 	params []interface{},
 	originalReq *request.JSONRPCRequest,
 ) (map[string]interface{}, error) {
-	// Create a per-request timeout context to prevent one slow call
-	// from consuming the entire parent context budget.
+	// Create a per-request timeout context
 	subCtx, cancel := context.WithTimeout(ctx, subRequestTimeout)
 	defer cancel()
 
@@ -381,4 +482,19 @@ func (p *RequestProcessor) callSteemd(
 	}
 
 	return p.httpClient.RequestWithRetry(subCtx, upstreamURL, payload, headers, retryCfg)
+}
+
+// deepCopyMap creates a deep copy of a map[string]interface{} by
+// round-tripping through JSON. Used before caching to prevent shared
+// reference issues between concurrent requests.
+func deepCopyMap(m map[string]interface{}) map[string]interface{} {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return m // fallback: return original (should not happen with JSON-RPC responses)
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return m
+	}
+	return result
 }

--- a/internal/handlers/get_state_workaround.go
+++ b/internal/handlers/get_state_workaround.go
@@ -126,11 +126,26 @@ func isGetStateUnsupportedSubPath(jsonrpcReq *request.JSONRPCRequest) (string, s
 	}
 
 	params, ok := jsonrpcReq.Params.([]interface{})
-	if !ok || len(params) != 1 {
+	if !ok {
 		return "", "", false
 	}
-	path, ok := params[0].(string)
-	if !ok {
+
+	// Extract the path string from params.
+	// Two formats after translateLegacyAPI:
+	//   - direct method: params = ["/@user/transfers"]           (len=1)
+	//   - call-style:    params = ["condenser_api","get_state",["/@user/transfers"]]  (len=3)
+	var path string
+	switch len(params) {
+	case 1:
+		path, ok = params[0].(string)
+	case 3:
+		// call-style: params[2] is the actual argument
+		var args []interface{}
+		if args, ok = params[2].([]interface{}); ok && len(args) >= 1 {
+			path, ok = args[0].(string)
+		}
+	}
+	if !ok || path == "" {
 		return "", "", false
 	}
 

--- a/internal/handlers/get_state_workaround.go
+++ b/internal/handlers/get_state_workaround.go
@@ -20,18 +20,20 @@ import (
 // ============================================================================
 //
 // Background:
-//   steemd's condenser_api.get_state only supports a limited set of sub-paths:
-//     - /@user/transfers, /@user/recent-replies
-//     - /@user/posts, /@user/comments, /@user/blog, /@user/feed
+//   steemd's condenser_api.get_state supports a limited set of sub-paths:
+//     - /@user/recent-replies, /@user/posts, /@user/comments
+//     - /@user/blog, /@user/feed
 //
-//   The following sub-paths were NEVER implemented in steemd's get_state:
+//   The following sub-paths are NOT handled by steemd's get_state:
+//     - /@user/transfers
 //     - /@user/author-rewards
 //     - /@user/curation-rewards
 //     - /@user/delegations
 //
 //   Calling get_state with these paths causes steemd to return
-//   -32602 "Invalid parameters". Some third-party clients or direct API
-//   calls still request these paths, causing 504 timeouts.
+//   -32602 "Invalid parameters". Some third-party clients (old wallet),
+//   direct API calls, and SSR requests still use these paths, causing
+//   504 timeouts when the client retries/waits for ~350 seconds.
 //
 //   The new wallet (Next.js) has completely migrated away from get_state
 //   and uses direct API calls (get_account_history, get_vesting_delegations).
@@ -40,7 +42,7 @@ import (
 //   Intercept get_state requests with unsupported sub-paths at the jussi
 //   layer and emulate the expected get_state response by:
 //     1. Calling get_state("/@username") for base account data
-//     2. Calling get_account_history for author/curation rewards
+//     2. Calling get_account_history for transfers/author/curation rewards
 //     3. Calling get_vesting_delegations for delegation data
 //     4. Assembling a response in the same format get_state returns
 //
@@ -109,10 +111,10 @@ func cacheKeyDelegIn(username string) string {
 	return cacheKeyPrefix + "gs:deleg_in:" + username
 }
 
-// getStateSubPathRegex matches unsupported get_state sub-paths.
-// NOTE: "transfers" is intentionally excluded — steemd supports it natively.
+// getStateSubPathRegex matches get_state sub-paths that steemd does NOT handle.
+// All four sub-paths cause "Invalid parameters" and need emulation.
 var getStateSubPathRegex = regexp.MustCompile(
-	`^/?@([^/\s]+)/(author-rewards|curation-rewards|delegations)$`,
+	`^/?@([^/\s]+)/(transfers|author-rewards|curation-rewards|delegations)$`,
 )
 
 // isGetStateUnsupportedSubPath checks if a request is condenser_api.get_state
@@ -178,6 +180,9 @@ func (p *RequestProcessor) emulateGetStateSubPath(
 
 	// Step 2: Fetch sub-path-specific data (with caching)
 	switch subPath {
+	case "transfers":
+		p.fillRewardHistory(ctx, upstreamURL, jsonrpcReq, result, username, isTransferOp)
+
 	case "author-rewards":
 		p.fillRewardHistory(ctx, upstreamURL, jsonrpcReq, result, username, isAuthorRewardOp)
 
@@ -432,6 +437,17 @@ func isAuthorRewardOp(opType string) bool {
 
 func isCurationRewardOp(opType string) bool {
 	return opType == "curation_reward"
+}
+
+// isTransferOp matches all operation types that appear in the "transfers" tab.
+// This mirrors steemd's native behavior for get_state("/@user/transfers").
+func isTransferOp(opType string) bool {
+	switch opType {
+	case "transfer", "transfer_to_vesting", "transfer_from_savings",
+		"transfer_to_savings", "cancel_transfer_from_savings":
+		return true
+	}
+	return false
 }
 
 // getSteemdUpstreamURL resolves the upstream URL for condenser_api requests.

--- a/internal/handlers/processor.go
+++ b/internal/handlers/processor.go
@@ -109,8 +109,8 @@ func (p *RequestProcessor) ProcessSingleRequest(ctx context.Context, jsonrpcReq 
 	translateLegacyAPI(jsonrpcReq)
 
 	// TEMPORARY WORKAROUND: Intercept get_state with unsupported sub-paths
-	// (author-rewards, curation-rewards, delegations) that steemd does not
-	// handle. See get_state_workaround.go for full documentation.
+	// (transfers, author-rewards, curation-rewards, delegations) that steemd
+	// does not handle. See get_state_workaround.go for full documentation.
 	// TODO: Remove this block once all clients migrate to new wallet.
 	if username, subPath, ok := isGetStateUnsupportedSubPath(jsonrpcReq); ok {
 		span.SetAttributes(attribute.String("jussi.workaround", "get_state_subpath"))

--- a/internal/handlers/processor.go
+++ b/internal/handlers/processor.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -112,7 +113,15 @@ func (p *RequestProcessor) ProcessSingleRequest(ctx context.Context, jsonrpcReq 
 	// (transfers, author-rewards, curation-rewards, delegations) that steemd
 	// does not handle. See get_state_workaround.go for full documentation.
 	// TODO: Remove this block once all clients migrate to new wallet.
+	slog.Info("DEBUG: checking workaround",
+		"api", jsonrpcReq.URN.API,
+		"method", jsonrpcReq.URN.Method,
+		"namespace", jsonrpcReq.URN.Namespace,
+		"params_type", fmt.Sprintf("%T", jsonrpcReq.Params),
+		"params", fmt.Sprintf("%v", jsonrpcReq.Params),
+	)
 	if username, subPath, ok := isGetStateUnsupportedSubPath(jsonrpcReq); ok {
+		slog.Info("DEBUG: workaround triggered", "username", username, "subPath", subPath)
 		span.SetAttributes(attribute.String("jussi.workaround", "get_state_subpath"))
 		span.SetAttributes(attribute.String("jussi.workaround.subpath", subPath))
 		span.SetAttributes(attribute.String("jussi.workaround.username", username))

--- a/internal/handlers/processor.go
+++ b/internal/handlers/processor.go
@@ -108,6 +108,25 @@ func (p *RequestProcessor) ProcessSingleRequest(ctx context.Context, jsonrpcReq 
 	// before routing so the URN matches the correct upstream config entry.
 	translateLegacyAPI(jsonrpcReq)
 
+	// TEMPORARY WORKAROUND: Intercept get_state with unsupported sub-paths
+	// (author-rewards, curation-rewards, delegations) that steemd does not
+	// handle. See get_state_workaround.go for full documentation.
+	// TODO: Remove this block once all clients migrate to new wallet.
+	if username, subPath, ok := isGetStateUnsupportedSubPath(jsonrpcReq); ok {
+		span.SetAttributes(attribute.String("jussi.workaround", "get_state_subpath"))
+		span.SetAttributes(attribute.String("jussi.workaround.subpath", subPath))
+		span.SetAttributes(attribute.String("jussi.workaround.username", username))
+
+		resp, err := p.emulateGetStateSubPath(ctx, jsonrpcReq, username, subPath)
+		if err != nil {
+			telemetry.RecordSpanError(span, err)
+			RequestsTotal.WithLabelValues(jsonrpcReq.URN.Namespace, jsonrpcReq.URN.Method, "workaround_error").Inc()
+			return nil, fmt.Errorf("get_state workaround failed: %w", err)
+		}
+		RequestsTotal.WithLabelValues(jsonrpcReq.URN.Namespace, jsonrpcReq.URN.Method, "workaround_success").Inc()
+		return resp, nil
+	}
+
 	// Add span attributes
 	telemetry.AddSpanAttributes(span, map[string]string{
 		"jussi.namespace":  jsonrpcReq.URN.Namespace,


### PR DESCRIPTION
## Problem

`steemd` condenser_api.get_state does NOT handle the following sub-paths — it returns `-32602 "Invalid parameters"`:

- `/@user/transfers`
- `/@user/author-rewards`
- `/@user/curation-rewards`
- `/@user/delegations`

The old wallet (wallet-legacy) and third-party clients still call `get_state` with these paths. When steemd rejects them, the wallet SSR retries/waits for **~350 seconds** before timing out, causing **504 Gateway Timeout** on steemitwallet.com / wallet.steemitdev.com.

## Solution

Intercept these requests at the jussi layer and emulate the expected get_state response by:

1. Calling `get_state("/@username")` for base account data
2. Calling `get_account_history` for transfers/author-rewards/curation-rewards (filtered by op type)
3. Calling `get_vesting_delegations` + `list_vesting_delegations` for delegations
4. Assembling a response in the same format get_state returns

### Sub-path op-type filters

| Sub-path | Included operations |
|---|---|
| `transfers` | `transfer`, `transfer_to_vesting`, `transfer_from_savings`, `transfer_to_savings`, `cancel_transfer_from_savings` |
| `author-rewards` | `author_reward`, `comment_benefactor_reward` |
| `curation-rewards` | `curation_reward` |
| `delegations` | `delegate_vesting_shares` (outgoing + incoming) |

### Redis caching

Fine-grained cache keys maximize reuse across sub-paths for the same user:

- `{prefix}gs:base:{username}` — base get_state (reused by all sub-paths)
- `{prefix}gs:hist:{username}` — get_account_history (reused by transfers + rewards)
- `{prefix}gs:deleg_out:{username}` — outgoing delegations
- `{prefix}gs:deleg_in:{username}` — incoming delegations

TTL: 10 seconds. Async cache writes. Prefix configurable via `JUSSI_CACHE_KEY_PREFIX`.

## Changes

- `internal/handlers/get_state_workaround.go` — new file (~510 lines): workaround logic, caching, helpers
- `internal/handlers/processor.go` (+3 lines): intercept block after `translateLegacyAPI`
- `internal/config/config.go` (+4 lines): `JUSSI_CACHE_KEY_PREFIX` env var documentation

## Removal

Delete `get_state_workaround.go` and remove the `TEMPORARY WORKAROUND` block in `processor.go` once all clients migrate to the new wallet (Next.js) or direct API calls. Track via `workaround_success` Prometheus metric.

## Testing

- `go build ./...` — pass
- `go test ./...` — pass
- Log analysis confirms all four sub-paths trigger 504s on current deployment

## Commits

1. `1a35e8f` — base workaround for author-rewards/curation-rewards/delegations
2. `b3917ac` — fine-grained Redis cache
3. `389e1ec` — add transfers sub-path support