### PR TITLE
fix: translate all APIs to condenser_api when translate_to_appbase is true

### DIFF
--- a/internal/handlers/processor.go
+++ b/internal/handlers/processor.go
@@ -53,46 +53,49 @@ func NewRequestProcessor(
 	}
 }
 
-// legacyAPIs maps old-style API namespaces that must be translated to
-// condenser_api for steemd 0.23.x+ appbase compatibility.
-// These methods (e.g. database_api.get_state) are legacy and will be
-// removed in future steemd versions; condenser_api provides backward
-// compatibility in the meantime.
-var legacyAPIs = map[string]bool{
-	"database_api": true,
-}
-
-// translateLegacyAPI translates old-style API methods (e.g. database_api.get_state)
-// to their condenser_api equivalents. This must run before routing so the URN
-// matches the correct upstream entry in config (e.g. appbase.condenser_api.get_state → hivemind).
+// translateToAppbase translates API calls to condenser_api when the upstream
+// namespace is configured with translate_to_appbase: true. This matches the
+// legacy Python jussi behavior where all non-condenser_api methods (e.g.
+// network_broadcast_api, database_api, follow_api) are rewritten to
+// condenser_api so that appbase-style steemd nodes can handle them.
 //
 // Two request formats are handled:
-//  1. call-style: method="call", params=["database_api","get_state",args]
-//     → translate params[0] to "condenser_api" so the upstream receives the appbase method
-//  2. direct method: method="database_api.get_state", params=args
-//     → translate the method string to "condenser_api.get_state"
-func translateLegacyAPI(jsonrpcReq *request.JSONRPCRequest) {
-	if !legacyAPIs[jsonrpcReq.URN.API] {
+//  1. call-style:  method="call", params=["network_broadcast_api","method",args]
+//     → translate params[0] to "condenser_api"
+//  2. direct method: method="network_broadcast_api.method", params=args
+//     → translate the method string to "condenser_api.method"
+func translateToAppbase(jsonrpcReq *request.JSONRPCRequest, router *upstream.Router) {
+	api := jsonrpcReq.URN.API
+	if api == "condenser_api" || api == "jsonrpc" {
 		return
 	}
 
-	oldAPI := jsonrpcReq.URN.API
+	shouldTranslate := false
+	if jsonrpcReq.URN.Namespace == "steemd" {
+		shouldTranslate = router.ShouldTranslateToAppbase("steemd")
+	} else if jsonrpcReq.URN.Namespace == "appbase" {
+		// Direct method format like "database_api.get_state" is parsed as
+		// namespace="appbase" by the regex. Only translate known legacy APIs.
+		if api == "database_api" {
+			shouldTranslate = true
+		}
+	}
+
+	if !shouldTranslate {
+		return
+	}
+
+	oldAPI := api
 	jsonrpcReq.URN.API = "condenser_api"
-	// Switch namespace to "appbase" so routing matches config entries
-	// like "appbase.condenser_api.get_state" instead of falling through
-	// the "steemd" namespace to the generic steemd upstream.
 	jsonrpcReq.URN.Namespace = "appbase"
 
 	if jsonrpcReq.Method == "call" {
-		// call-style: params=[api_name, method_name, args]
-		// Translate params[0] from "database_api" to "condenser_api"
 		if paramsSlice, ok := jsonrpcReq.Params.([]interface{}); ok && len(paramsSlice) >= 1 {
 			if apiName, ok := paramsSlice[0].(string); ok && apiName == oldAPI {
 				paramsSlice[0] = "condenser_api"
 			}
 		}
 	} else {
-		// Direct method: "database_api.get_state" → "condenser_api.get_state"
 		jsonrpcReq.Method = strings.Replace(jsonrpcReq.Method, oldAPI+".", "condenser_api.", 1)
 	}
 }
@@ -105,9 +108,8 @@ func (p *RequestProcessor) ProcessSingleRequest(ctx context.Context, jsonrpcReq 
 	)
 	defer span.End()
 
-	// Translate legacy API methods (e.g. database_api.get_state → condenser_api.get_state)
-	// before routing so the URN matches the correct upstream config entry.
-	translateLegacyAPI(jsonrpcReq)
+	// Translate API calls to condenser_api when the upstream requires appbase format.
+	translateToAppbase(jsonrpcReq, p.router)
 
 	// TEMPORARY WORKAROUND: Intercept get_state with unsupported sub-paths
 	// (transfers, author-rewards, curation-rewards, delegations) that steemd

--- a/internal/handlers/processor_translate_test.go
+++ b/internal/handlers/processor_translate_test.go
@@ -4,11 +4,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steemit/jussi/internal/config"
 	"github.com/steemit/jussi/internal/request"
 	"github.com/steemit/jussi/internal/urn"
+	"github.com/steemit/jussi/internal/upstream"
 )
 
-func TestTranslateLegacyAPI_directMethod(t *testing.T) {
+func newTestRouter(translateNamespaces ...string) *upstream.Router {
+	cfg := &config.UpstreamRawConfig{}
+	for _, ns := range translateNamespaces {
+		cfg.Upstreams = append(cfg.Upstreams, config.UpstreamDefinition{
+			Name:               ns,
+			TranslateToAppbase: true,
+		})
+	}
+	r, _ := upstream.NewRouter(cfg)
+	return r
+}
+
+func TestTranslateToAppbase_directMethod(t *testing.T) {
+	router := newTestRouter("steemd")
+
 	tests := []struct {
 		name           string
 		inputAPI       string
@@ -57,7 +73,7 @@ func TestTranslateLegacyAPI_directMethod(t *testing.T) {
 				},
 			}
 
-			translateLegacyAPI(req)
+			translateToAppbase(req, router)
 
 			if req.URN.API != tt.expectedAPI {
 				t.Errorf("URN.API = %q, want %q", req.URN.API, tt.expectedAPI)
@@ -72,7 +88,9 @@ func TestTranslateLegacyAPI_directMethod(t *testing.T) {
 	}
 }
 
-func TestTranslateLegacyAPI_callStyle(t *testing.T) {
+func TestTranslateToAppbase_callStyle(t *testing.T) {
+	router := newTestRouter("steemd")
+
 	tests := []struct {
 		name           string
 		params         []interface{}
@@ -98,6 +116,11 @@ func TestTranslateLegacyAPI_callStyle(t *testing.T) {
 			params:         []interface{}{"database_api", "get_account_history", []interface{}{"user", -1, 20}},
 			expectedParam0: "condenser_api",
 		},
+		{
+			name:           "call broadcast_transaction_synchronous via network_broadcast_api",
+			params:         []interface{}{"network_broadcast_api", "broadcast_transaction_synchronous", []interface{}{map[string]interface{}{"ref_block_num": float64(62429)}}},
+			expectedParam0: "condenser_api",
+		},
 	}
 
 	for _, tt := range tests {
@@ -107,12 +130,12 @@ func TestTranslateLegacyAPI_callStyle(t *testing.T) {
 				Params: tt.params,
 				URN: &urn.URN{
 					Namespace: "steemd",
-					API:       "database_api",
+					API:       tt.params[0].(string),
 					Method:    tt.params[1].(string),
 				},
 			}
 
-			translateLegacyAPI(req)
+			translateToAppbase(req, router)
 
 			// Method should remain "call"
 			if req.Method != "call" {
@@ -137,8 +160,9 @@ func TestTranslateLegacyAPI_callStyle(t *testing.T) {
 	}
 }
 
-func TestTranslateLegacyAPI_callStyle_preservesMethodAndArgs(t *testing.T) {
-	// Verify that params[1] (method name) and params[2] (args) are unchanged
+func TestTranslateToAppbase_callStyle_preservesMethodAndArgs(t *testing.T) {
+	router := newTestRouter("steemd")
+
 	req := &request.JSONRPCRequest{
 		Method: "call",
 		Params: []interface{}{"database_api", "get_state", []interface{}{"/@test/transfers"}},
@@ -149,7 +173,7 @@ func TestTranslateLegacyAPI_callStyle_preservesMethodAndArgs(t *testing.T) {
 		},
 	}
 
-	translateLegacyAPI(req)
+	translateToAppbase(req, router)
 
 	paramsSlice := req.Params.([]interface{})
 	if paramsSlice[1] != "get_state" {
@@ -164,7 +188,9 @@ func TestTranslateLegacyAPI_callStyle_preservesMethodAndArgs(t *testing.T) {
 	}
 }
 
-func TestTranslateLegacyAPI_nonLegacyAPI(t *testing.T) {
+func TestTranslateToAppbase_condenserAPIUnchanged(t *testing.T) {
+	router := newTestRouter("steemd")
+
 	req := &request.JSONRPCRequest{
 		Method: "condenser_api.get_state",
 		URN: &urn.URN{
@@ -174,7 +200,7 @@ func TestTranslateLegacyAPI_nonLegacyAPI(t *testing.T) {
 		},
 	}
 
-	translateLegacyAPI(req)
+	translateToAppbase(req, router)
 
 	if req.URN.API != "condenser_api" {
 		t.Errorf("URN.API should remain %q, got %q", "condenser_api", req.URN.API)
@@ -184,7 +210,9 @@ func TestTranslateLegacyAPI_nonLegacyAPI(t *testing.T) {
 	}
 }
 
-func TestTranslateLegacyAPI_followAPI(t *testing.T) {
+func TestTranslateToAppbase_followAPI_appbaseNamespace(t *testing.T) {
+	router := newTestRouter("steemd")
+
 	req := &request.JSONRPCRequest{
 		Method: "follow_api.get_blog",
 		URN: &urn.URN{
@@ -194,41 +222,82 @@ func TestTranslateLegacyAPI_followAPI(t *testing.T) {
 		},
 	}
 
-	translateLegacyAPI(req)
+	translateToAppbase(req, router)
 
 	if req.URN.API != "follow_api" {
 		t.Errorf("URN.API should remain %q, got %q", "follow_api", req.URN.API)
 	}
 }
 
-func TestTranslateLegacyAPI_urnString(t *testing.T) {
+func TestTranslateToAppbase_followAPI_steemdNamespace(t *testing.T) {
+	router := newTestRouter("steemd")
+
 	req := &request.JSONRPCRequest{
-		Method: "database_api.get_state",
+		Method: "call",
+		Params: []interface{}{"follow_api", "get_blog", []interface{}{"user", 10, 20}},
 		URN: &urn.URN{
-			Namespace: "appbase",
-			API:       "database_api",
-			Method:    "get_state",
-			Params:    []interface{}{"/trending"},
+			Namespace: "steemd",
+			API:       "follow_api",
+			Method:    "get_blog",
 		},
 	}
 
-	translateLegacyAPI(req)
+	translateToAppbase(req, router)
 
-	expectedURN := "appbase.condenser_api.get_state"
 	if req.URN.API != "condenser_api" {
 		t.Errorf("URN.API = %q, want %q", req.URN.API, "condenser_api")
 	}
-	if req.URN.Namespace != "appbase" {
-		t.Errorf("URN.Namespace = %q, want %q", req.URN.Namespace, "appbase")
-	}
-	urnStr := req.URN.String()
-	if !strings.HasPrefix(urnStr, expectedURN) {
-		t.Errorf("URN.String() = %q, want prefix %q", urnStr, expectedURN)
+	paramsSlice := req.Params.([]interface{})
+	if paramsSlice[0] != "condenser_api" {
+		t.Errorf("Params[0] = %q, want %q", paramsSlice[0], "condenser_api")
 	}
 }
 
-func TestTranslateLegacyAPI_callStyle_namespaceSwitch(t *testing.T) {
-	// Verify that steemd namespace is switched to appbase for correct routing
+func TestTranslateToAppbase_noTranslationWhenNotConfigured(t *testing.T) {
+	router := newTestRouter() // empty - no translate_to_appbase
+
+	req := &request.JSONRPCRequest{
+		Method: "call",
+		Params: []interface{}{"network_broadcast_api", "broadcast_transaction_synchronous", []interface{}{}},
+		URN: &urn.URN{
+			Namespace: "steemd",
+			API:       "network_broadcast_api",
+			Method:    "broadcast_transaction_synchronous",
+		},
+	}
+
+	translateToAppbase(req, router)
+
+	if req.URN.API != "network_broadcast_api" {
+		t.Errorf("URN.API should remain %q when translate not configured, got %q", "network_broadcast_api", req.URN.API)
+	}
+}
+
+func TestTranslateToAppbase_urnString(t *testing.T) {
+	router := newTestRouter("steemd")
+
+	req := &request.JSONRPCRequest{
+		Method: "call",
+		Params: []interface{}{"network_broadcast_api", "broadcast_transaction_synchronous", []interface{}{}},
+		URN: &urn.URN{
+			Namespace: "steemd",
+			API:       "network_broadcast_api",
+			Method:    "broadcast_transaction_synchronous",
+		},
+	}
+
+	translateToAppbase(req, router)
+
+	expectedPrefix := "appbase.condenser_api.broadcast_transaction_synchronous"
+	urnStr := req.URN.String()
+	if !strings.HasPrefix(urnStr, expectedPrefix) {
+		t.Errorf("URN.String() = %q, want prefix %q", urnStr, expectedPrefix)
+	}
+}
+
+func TestTranslateToAppbase_callStyle_namespaceSwitch(t *testing.T) {
+	router := newTestRouter("steemd")
+
 	req := &request.JSONRPCRequest{
 		Method: "call",
 		Params: []interface{}{"database_api", "get_state", []interface{}{"/@user/transfers"}},
@@ -239,7 +308,7 @@ func TestTranslateLegacyAPI_callStyle_namespaceSwitch(t *testing.T) {
 		},
 	}
 
-	translateLegacyAPI(req)
+	translateToAppbase(req, router)
 
 	if req.URN.Namespace != "appbase" {
 		t.Errorf("URN.Namespace = %q, want %q (appbase for routing to hivemind)", req.URN.Namespace, "appbase")


### PR DESCRIPTION
## Summary

- `network_broadcast_api.broadcast_transaction_synchronous` requests failed with "Could not find method" error
- Root cause: Go version's `translateLegacyAPI` only hardcoded translation for `database_api` → `condenser_api`, ignoring `network_broadcast_api` and other APIs
- The `translate_to_appbase: true` config flag was correctly parsed by the Router but never used in request processing
- Fix: replaced `translateLegacyAPI` with `translateToAppbase` that reads the flag from Router config and translates ALL non-`condenser_api` APIs when enabled (matching legacy Python jussi behavior)

## Test plan

- [x] Added test case for `network_broadcast_api` translation
- [x] Added test case for `follow_api` (steemd namespace) translation
- [x] Added test case for no translation when `translate_to_appbase` is not configured
- [x] All existing tests pass (`go test ./...`)
- [ ] Verify `broadcast_transaction_synchronous` requests work correctly after deployment